### PR TITLE
chore(deps): tighten Dependabot config — group vitest, ignore sonar v7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,13 +27,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # vitest + @vitest/coverage-v8 ALWAYS ship together — same release
+      # cadence, peer-dep'd by version. We group ALL update-types so that
+      # a vitest 4.x major never lands on its own without coverage-v8 4.x;
+      # closing them as separate PRs would cause one to break against
+      # the other on develop.
       vitest:
         patterns:
           - "vitest"
           - "@vitest/*"
-        update-types:
-          - "minor"
-          - "patch"
     ignore:
       # tar / fastembed: wontfix con ADR-004 hasta v0.5 (swap embedder).
       # Bumps automaticos no resuelven el problema y solo crean ruido.
@@ -55,3 +57,11 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    ignore:
+      # SonarSource/sonarqube-scan-action: ignore major bumps. v7 changed
+      # the token contract and reproducibly returns HTTP 401 against our
+      # self-hosted SonarQube 26.4 instance with the same SONAR_TOKEN that
+      # works on v6. Re-evaluate when SonarQube server is upgraded.
+      - dependency-name: "SonarSource/sonarqube-scan-action"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Que cambia

- Drop \`update-types: [minor, patch]\` filter on the \`vitest\` group so MAJOR bumps are also batched. \`vitest\` and \`@vitest/coverage-v8\` are peer-dep'd by version; landing one without the other breaks develop.
- Add explicit \`ignore\` for \`SonarSource/sonarqube-scan-action\` MAJOR bumps. v7 reproducibly throws HTTP 401 against our self-hosted SonarQube 26.4 with a token that v6 accepts. Re-evaluate once the server is upgraded.

## Por que

Closes the 3 problematic Dependabot PRs from the first weekly run:
- #5 SonarSource/sonarqube-scan-action 6→7 — auth incompatibility
- #9 vitest 3→4 — major bump that needs validation
- #10 @vitest/coverage-v8 3→4 — twin of #9, must ship together

When Dependabot reopens vitest 4.x it will arrive as a single grouped PR.

## Tipo

- [x] chore — deps/CI config

## Checklist

No production code touched. The config change applies on next Dependabot run.