### PR TITLE
fix(retrieval): wire AsyncEmbeddingWorker into mcp-server bootstrap (B-MCP-3)

### DIFF
--- a/code/src/bootstrap/mcp-server-entrypoint.ts
+++ b/code/src/bootstrap/mcp-server-entrypoint.ts
@@ -41,6 +41,14 @@ async function main(): Promise<number> {
     stdout: process.stdout,
   });
 
+  // Drain the embedding queue in the background. Without this the
+  // `embedding_queue` rows that `mem.remember` enqueues never get
+  // embedded — `mem.recall` silently falls back to BM25-only and the
+  // semantic-recall guarantee of the product is broken (Bug B-MCP-3).
+  // The worker is constructed by `buildRetrievalWiring`; the bootstrap
+  // entrypoint only owns its lifecycle.
+  container.retrieval.embeddingWorker.start();
+
   // The closure mutates `value` through the `state` object so the
   // narrow analysis in TypeScript / ESLint cannot prove the field is
   // always `false` at the `try`/`finally` boundary below.
@@ -50,9 +58,15 @@ async function main(): Promise<number> {
     state.value = true;
     container.logger.info({ signal }, "mcp-server received signal; shutting down");
     server.stop();
-    void shutdown().finally(() => {
-      process.exit(signal === "SIGTERM" ? 143 : 130);
-    });
+    // Stop the embedding worker before closing the database. The
+    // worker awaits any in-flight `drainBatch` so we cannot pull the
+    // SQLite connection out from under it.
+    void container.retrieval.embeddingWorker
+      .stop()
+      .finally(() => shutdown())
+      .finally(() => {
+        process.exit(signal === "SIGTERM" ? 143 : 130);
+      });
   };
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
@@ -75,7 +89,10 @@ async function main(): Promise<number> {
     );
     return 1;
   } finally {
-    if (!state.value) await shutdown();
+    if (!state.value) {
+      await container.retrieval.embeddingWorker.stop();
+      await shutdown();
+    }
   }
 }
 

--- a/code/src/composition/container.ts
+++ b/code/src/composition/container.ts
@@ -129,6 +129,18 @@ export interface Container {
 
   readonly database: DatabaseConnection;
 
+  /**
+   * Canonical workspace id pinned at construction time. Bootstrap
+   * entrypoints resolve it from `<root>/.recall/config.json` BEFORE
+   * `buildContainer` is called and pass it as
+   * {@link ContainerOptions.workspaceId}; when absent (the
+   * `skipDatabase: true` pre-init path), a deterministic placeholder
+   * UUID v7 is supplied. Exposed so the bootstrap can wire process
+   * lifecycle helpers (e.g. drive `retrieval.embeddingWorker`) without
+   * re-resolving the id.
+   */
+  readonly workspaceId: WorkspaceId;
+
   readonly workspace: WorkspaceWiring;
   readonly encryption: EncryptionWiring;
   readonly secrets: SecretsWiring;
@@ -270,6 +282,7 @@ export function buildContainer(options: ContainerOptions): Container {
     idGenerator: shared.idGenerator,
     database: options.database,
     embedder: shared.retrievalEmbedder,
+    workspaceId,
   });
   const memory = buildMemoryWiring({
     logger,
@@ -423,6 +436,7 @@ export function buildContainer(options: ContainerOptions): Container {
     idGenerator: shared.idGenerator,
     embedder: shared.embedder,
     database: options.database,
+    workspaceId,
     workspace: fullWorkspaceWiring,
     encryption,
     secrets,

--- a/code/src/composition/wiring/retrieval-wiring.ts
+++ b/code/src/composition/wiring/retrieval-wiring.ts
@@ -13,12 +13,14 @@ import type { DatabaseConnection } from "../../shared/application/ports/database
 import type { Clock } from "../../shared/application/ports/clock.port.ts";
 import type { IdGenerator } from "../../shared/application/ports/id-generator.port.ts";
 import type { Logger } from "../../shared/application/ports/logger.port.ts";
+import type { WorkspaceId } from "../../shared/domain/value-objects/workspace-id.ts";
 import { CountTokensUseCase } from "../../modules/retrieval/application/use-cases/count-tokens.use-case.ts";
 import { EmbedAndPersistUseCase } from "../../modules/retrieval/application/use-cases/embed-and-persist.use-case.ts";
 import { GetContextBundleUseCase } from "../../modules/retrieval/application/use-cases/get-context-bundle.use-case.ts";
 import { RecallMemoryUseCase } from "../../modules/retrieval/application/use-cases/recall-memory.use-case.ts";
 import type { Embedder as RetrievalEmbedder } from "../../modules/retrieval/domain/services/embedder.ts";
 import {
+  AsyncEmbeddingWorker,
   SqliteEmbeddingQueueRepository,
   SqliteFts5LexicalSearch,
   SqliteMemoryProjectionRepository,
@@ -28,15 +30,22 @@ import {
 
 /**
  * Bag of retrieval-module use cases the rest of composition consumes
- * either directly (the embedding worker drains
- * `EmbedAndPersistUseCase`) or via mcp-server facades (`mem.context`
- * → `GetContextBundleUseCase`, `mem.recall` → `RecallMemoryUseCase`).
+ * either directly (`embeddingWorker` drains `EmbedAndPersistUseCase`)
+ * or via mcp-server facades (`mem.context` → `GetContextBundleUseCase`,
+ * `mem.recall` → `RecallMemoryUseCase`).
+ *
+ * `embeddingWorker` is constructed but NOT started here. The bootstrap
+ * entrypoint that owns the process lifecycle (`mcp-server-entrypoint.ts`)
+ * is responsible for calling `start()` after the container is built and
+ * `stop()` on shutdown. Tests that do not need background draining can
+ * leave it idle.
  */
 export interface RetrievalWiring {
   readonly getContextBundle: GetContextBundleUseCase;
   readonly recallMemory: RecallMemoryUseCase;
   readonly countTokens: CountTokensUseCase;
   readonly embedAndPersist: EmbedAndPersistUseCase;
+  readonly embeddingWorker: AsyncEmbeddingWorker;
   readonly projections: SqliteMemoryProjectionRepository;
   readonly embeddingQueue: SqliteEmbeddingQueueRepository;
   readonly tokenCounter: TiktokenTokenCounter;
@@ -48,6 +57,12 @@ export interface RetrievalWiringOptions {
   readonly idGenerator: IdGenerator;
   readonly database: DatabaseConnection;
   readonly embedder: RetrievalEmbedder;
+  /**
+   * Workspace whose embedding queue the worker drains. The wiring
+   * constructs the worker bound to this id so the bootstrap entrypoint
+   * only needs to call `start()` / `stop()` to control the lifecycle.
+   */
+  readonly workspaceId: WorkspaceId;
 }
 
 /**
@@ -98,11 +113,17 @@ export function buildRetrievalWiring(
     options.logger,
   );
 
+  const embeddingWorker = new AsyncEmbeddingWorker(embedAndPersist, {
+    workspaceId: options.workspaceId,
+    logger: options.logger,
+  });
+
   return {
     getContextBundle,
     recallMemory,
     countTokens,
     embedAndPersist,
+    embeddingWorker,
     projections,
     embeddingQueue,
     tokenCounter,

--- a/code/tests/integration/L-embedding-worker-drains.test.ts
+++ b/code/tests/integration/L-embedding-worker-drains.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Integration test — Flow L: AsyncEmbeddingWorker drains the queue.
+ *
+ * Regression for Bug B-MCP-3 (https://github.com/NetziTech/recall/issues/2):
+ * the worker class was implemented and unit-tested at 100% but no
+ * production code path instantiated it. Wire-up moved into
+ * `buildRetrievalWiring`, so every container exposes
+ * `retrieval.embeddingWorker`; this test asserts the contract end-to-end
+ * with a stub embedder so it never touches fastembed.
+ *
+ * Methodology — VALUES, not SHAPE (Phase-9 lesson):
+ *   1. Establish known state: `embedding_queue` has zero rows.
+ *   2. Invoke the recording use cases (one decision + one learning +
+ *      one entity). Assert the queue grew to exactly three rows and
+ *      `embedding_metadata` is still empty.
+ *   3. Start the worker. Poll until the queue drops to zero (cap at
+ *      ~5 s; the stub embedder is in-process and the idle poll is
+ *      200 ms, so the actual wall time is well under 1 s).
+ *   4. Assert the side table `embedding_metadata` now has one row per
+ *      enqueued memory, with the correct dimension, and that the stub
+ *      embedder was invoked.
+ *   5. Stop the worker — `stop()` must be idempotent and must await
+ *      any in-flight drain before returning.
+ *
+ * Why this catches B-MCP-3: the test fails if `embeddingWorker` is not
+ * wired (the field is missing) AND if the worker fails to drain (the
+ * poll times out and the side table stays empty). Both branches
+ * reproduce the production symptom that escaped the MVP suite.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Tags } from "../../src/shared/domain/value-objects/tags.ts";
+import { EntityKind } from "../../src/modules/memory/domain/value-objects/entity-kind.ts";
+import { LearningSeverity } from "../../src/modules/memory/domain/value-objects/learning-severity.ts";
+import { Scope } from "../../src/modules/memory/domain/value-objects/scope.ts";
+import {
+  buildTestContainer,
+  type TestContainer,
+} from "./_helpers/build-test-container.ts";
+
+interface QueueRow {
+  readonly id: string;
+  readonly target_kind: string;
+}
+
+interface MetadataRow {
+  readonly target_kind: string;
+  readonly target_row_id: string;
+  readonly embedded_text: string;
+  readonly dimension: number;
+}
+
+function readQueueRows(ctx: TestContainer): QueueRow[] {
+  const stmt = ctx.database.prepare(
+    "SELECT id, target_kind FROM embedding_queue ORDER BY enqueued_at_ms ASC",
+  );
+  return [...(stmt.all() as readonly QueueRow[])];
+}
+
+function readMetadataRows(ctx: TestContainer): MetadataRow[] {
+  const stmt = ctx.database.prepare(
+    "SELECT target_kind, target_row_id, embedded_text, dimension FROM embedding_metadata ORDER BY created_at_ms ASC",
+  );
+  return [...(stmt.all() as readonly MetadataRow[])];
+}
+
+async function waitForQueueDrain(
+  ctx: TestContainer,
+  options: { readonly timeoutMs?: number; readonly pollMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const pollMs = options.pollMs ?? 50;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (readQueueRows(ctx).length === 0) return;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  const remaining = readQueueRows(ctx);
+  throw new Error(
+    `embedding queue did not drain within ${timeoutMs}ms; remaining=${JSON.stringify(remaining)}`,
+  );
+}
+
+describe("integration / L / AsyncEmbeddingWorker drains the queue (B-MCP-3)", () => {
+  let ctx: TestContainer;
+
+  beforeEach(async () => {
+    ctx = await buildTestContainer();
+  });
+
+  afterEach(async () => {
+    // Stop is idempotent. We call it here in case a test errored
+    // between `start()` and its own `stop()` call so the timer
+    // does not leak into the next test.
+    await ctx.retrieval.embeddingWorker.stop();
+    await ctx.cleanup();
+  });
+
+  it("exposes the worker on the retrieval wiring", () => {
+    expect(ctx.retrieval.embeddingWorker).toBeDefined();
+    expect(typeof ctx.retrieval.embeddingWorker.start).toBe("function");
+    expect(typeof ctx.retrieval.embeddingWorker.stop).toBe("function");
+  });
+
+  it("drains a queue of three mixed-kind enqueues into embedding_metadata", async () => {
+    expect(readQueueRows(ctx)).toHaveLength(0);
+    expect(readMetadataRows(ctx)).toHaveLength(0);
+
+    const decision = await ctx.memory.recordDecision.record({
+      workspaceId: ctx.workspaceId,
+      sessionId: null,
+      title: "Adopt strict GitFlow on @netzi/recall repo",
+      rationale:
+        "Public homepage from npm needed a working repo URL; strict GitFlow enforces that main only ever ships through CI-validated PRs.",
+      tags: Tags.create(["governance", "release"]),
+      scope: Scope.project(),
+    });
+    expect(decision.embeddingEnqueued).toBe(true);
+
+    const learning = await ctx.memory.recordLearning.record({
+      workspaceId: ctx.workspaceId,
+      text: "Validate VALUES of MCP tool responses, not just SHAPE — the MVP suite let three production bugs escape because it asserted shapes only.",
+      severity: LearningSeverity.critical(),
+      tags: Tags.create(["testing", "regression"]),
+      scope: Scope.project(),
+    });
+    expect(learning.embeddingEnqueued).toBe(true);
+
+    const entity = await ctx.memory.recordEntity.record({
+      workspaceId: ctx.workspaceId,
+      name: "AsyncEmbeddingWorker",
+      kind: EntityKind.moduleKind(),
+      description:
+        "Background worker that drains embedding_queue. Owned by retrieval/infrastructure; lifecycle owned by the bootstrap entrypoint.",
+      tags: Tags.create(["retrieval", "background"]),
+      scope: Scope.project(),
+    });
+    expect(entity.embeddingEnqueued).toBe(true);
+
+    // Pre-condition for the value assertion below: queue grew to 3.
+    const queueBefore = readQueueRows(ctx);
+    expect(queueBefore).toHaveLength(3);
+    expect(queueBefore.map((r) => r.target_kind).sort()).toEqual([
+      "decision",
+      "entity",
+      "learning",
+    ]);
+    // The stub embedder has not been invoked by the worker yet; the
+    // recording use cases never call embed themselves.
+    expect(ctx.embedder.calls).toHaveLength(0);
+    expect(readMetadataRows(ctx)).toHaveLength(0);
+
+    ctx.retrieval.embeddingWorker.start();
+    await waitForQueueDrain(ctx);
+
+    // Post-conditions: queue empty, metadata grew by 3, stub recorded
+    // exactly one embed per enqueue, and the dimension matches the
+    // stub's contract (384, the BGESmallEN15 dim).
+    expect(readQueueRows(ctx)).toHaveLength(0);
+    const metadata = readMetadataRows(ctx);
+    expect(metadata).toHaveLength(3);
+    const persistedKinds = metadata.map((r) => r.target_kind).sort();
+    expect(persistedKinds).toEqual(["decision", "entity", "learning"]);
+    for (const row of metadata) {
+      expect(row.dimension).toBe(384);
+      expect(row.embedded_text.length).toBeGreaterThan(0);
+    }
+    expect(ctx.embedder.calls.length).toBeGreaterThanOrEqual(3);
+
+    await ctx.retrieval.embeddingWorker.stop();
+    // `stop()` is idempotent — calling it twice must not throw.
+    await ctx.retrieval.embeddingWorker.stop();
+  });
+
+  it("survives a transient embedder failure without dropping the queue row", async () => {
+    // First embed fails; subsequent calls succeed. The worker is
+    // expected to log a warning and leave the row in the queue with
+    // an incremented failure record. We assert narrowly: the stub
+    // got called (proves the worker actually ran) and the queue row
+    // is NOT silently dropped — it stays parked in the queue waiting
+    // for the next iteration after the backoff window. This guards
+    // the "fail-and-forget" anti-pattern that would re-introduce
+    // B-MCP-3-style data loss for items the embedder rejected once.
+    ctx.embedder.failNext = true;
+    const learning = await ctx.memory.recordLearning.record({
+      workspaceId: ctx.workspaceId,
+      text: "Worker survives transient embed failures.",
+      severity: LearningSeverity.tip(),
+      tags: Tags.create(["resilience"]),
+      scope: Scope.project(),
+    });
+    expect(learning.embeddingEnqueued).toBe(true);
+    expect(readQueueRows(ctx)).toHaveLength(1);
+
+    ctx.retrieval.embeddingWorker.start();
+    // Give the worker enough time to attempt the drain at least once.
+    // The stub's `failNext` is consumed on the first call, so any
+    // subsequent retry within the backoff window would also need to
+    // succeed — but the worker honours the 30 s default backoff so
+    // we do not assert the row was processed here, only that it was
+    // attempted and not dropped.
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && ctx.embedder.calls.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(ctx.embedder.calls.length).toBeGreaterThanOrEqual(1);
+    // The row stays in the queue — the failure is recorded on it,
+    // not dropped.
+    expect(readQueueRows(ctx)).toHaveLength(1);
+    expect(readMetadataRows(ctx)).toHaveLength(0);
+
+    await ctx.retrieval.embeddingWorker.stop();
+  });
+});

--- a/code/tests/integration/_helpers/build-test-container.ts
+++ b/code/tests/integration/_helpers/build-test-container.ts
@@ -279,6 +279,7 @@ export async function buildTestContainer(
     idGenerator,
     database,
     embedder: retrievalEmbedder,
+    workspaceId,
   });
   const memory = buildMemoryWiring({
     logger,


### PR DESCRIPTION
## Que cambia

Wire the `AsyncEmbeddingWorker` into the mcp-server bootstrap so the
`embedding_queue` actually drains in production. Cambios son
puramente de wiring + un test de regresion; no se toco el codigo del
worker ni el de las use cases.

## Por que

Fixes #2 — B-MCP-3 (critical). El worker existia y estaba testeado al
100% pero ningun bootstrap lo instanciaba. La cola crecia
indefinidamente y `mem.recall` caia silenciosamente a BM25-only
("fallback_reason: embedder_unavailable"), rompiendo la promesa
central del producto. El dogfood de Phase-9 dejo 64 rows en
`embedding_queue` con `attempts=0` — evidencia empirica del bug.

## Tipo de cambio

- [x] fix — bug fix
- [x] test — agrega tests

## Checklist

- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` y `npm run lint:tests` EXIT=0
- [x] `npm run validate:modules` EXIT=0 (cero violaciones ADR-001)
- [x] `npm run build` EXIT=0
- [x] `npm run test` EXIT=0 — 2504 tests passing en 206 archivos (was 2501 in 205)
- [x] Cero `any`, cero `as any`, cero `// @ts-ignore`
- [x] Tests nuevos cubren el cambio
- [ ] N/A — wire/protocolo MCP no cambia
- [ ] N/A — no introduce ADR
- [ ] HANDOFF.md se actualiza al cierre de la fase v0.1.2-beta.1, no en este PR

## E2E que validan VALORES

- [x] Los tests nuevos asertan valores reales (no solo shape)

El test `tests/integration/L-embedding-worker-drains.test.ts` sigue
la metodologia codificada en Phase-9:

1. Estado inicial conocido: `embedding_queue=0`, `embedding_metadata=0`.
2. Insertar 1 decision + 1 learning + 1 entity → la cola crece a 3
   filas (`target_kind` en `[decision, entity, learning]`).
3. Arrancar el worker, hacer poll hasta que la cola caiga a 0.
4. Asertar valores: queue=0, metadata=3 con `dimension=384` y
   `embedded_text` no vacio, stub embedder invocado >=3 veces.
5. `stop()` idempotente.

Un segundo caso valida que el worker sobrevive un fallo transitorio
del embedder (`failNext=true`) sin perder la fila de la cola — guarda
contra el anti-patron "fail-and-forget" que reintroduciria una
variante de B-MCP-3.

## Notas para el reviewer

**Decisiones de wiring**:

- `AsyncEmbeddingWorker` se construye en `buildRetrievalWiring`, no
  en el bootstrap entrypoint. La razon: la wiring helper es donde se
  ensamblan los use cases retrieval; el entrypoint solo controla
  ciclos de vida del proceso. Esto deja `RetrievalWiring.embeddingWorker`
  disponible para tests y cualquier futuro driver (CLI long-running,
  daemon mode).
- `Container` ahora expone `workspaceId` publicamente. Antes vivia
  como local en `buildContainer`. Util para el bootstrap del MCP
  server (no se ejercita en este PR pero queda disponible para
  proximos drivers).
- En el SIGINT/SIGTERM path: `worker.stop()` se awaita antes de
  `shutdown()` para que el drain en vuelo no quede a la deriva
  cuando se cierra el handle de SQLite.
- **No toco `cli-entrypoint.ts`**. El HANDOFF lo menciona "para
  comandos long-running" pero el CLI hoy son one-shots. Es scope
  creep; lo dejo para una iteracion separada si surge el caso.

**Que NO valida este PR**:

- Que el path real con `FastembedEmbedder` funcione end-to-end. Para
  eso hace falta un E2E con descarga real del modelo desde GCS —
  posible pero costoso (30+s en cold cache). El test de integracion
  con stub valida el contrato; el real-fastembed quedaria para una
  validacion de release adicional.