### PR TITLE
feat(mcp-server): mem.recall accepts optional min_score threshold (B-MCP-5)

### DIFF
--- a/code/src/composition/facades/mcp-server-facades.ts
+++ b/code/src/composition/facades/mcp-server-facades.ts
@@ -369,7 +369,7 @@ export class RecallMemoryFacadeAdapter implements RecallMemoryFacade {
       weights: RelevanceWeights.defaults(),
     });
 
-    const entries: MemoryEntryWire[] = result.getEntries().map((entry) => ({
+    const allEntries: MemoryEntryWire[] = result.getEntries().map((entry) => ({
       id: entry.id,
       kind: queryKindToWire(entry.kind.value),
       content: entry.preview.toString(),
@@ -384,6 +384,17 @@ export class RecallMemoryFacadeAdapter implements RecallMemoryFacade {
           : entry.lastUsedAt.toEpochMs(),
       tags: Object.freeze([...entry.tags.toArray()]),
     }));
+
+    // Apply the optional `min_score` filter post-hoc. The Zod schema
+    // validates the range (0..1); the use case is unaware of the
+    // threshold so this stays a wire-only concern. `total_candidates`
+    // continues to reflect the PRE-filter pool so a caller can detect
+    // an aggressive threshold ("found 12 candidates, kept 3").
+    const minScore = input.min_score;
+    const entries =
+      minScore === undefined
+        ? allEntries
+        : allEntries.filter((e) => e.score >= minScore);
 
     const out: RecallOutputWire = {
       results: Object.freeze(entries),

--- a/code/src/modules/mcp-server/application/dtos/wire-types.dto.ts
+++ b/code/src/modules/mcp-server/application/dtos/wire-types.dto.ts
@@ -209,6 +209,25 @@ export interface RecallInputWire {
   scope?: ScopeWire | undefined;
   module?: string | undefined;
   include_superseded?: boolean | undefined;
+  /**
+   * Optional minimum relevance score (`0..1`) applied post-hoc to the
+   * ranked results. Entries whose final `score` is strictly below this
+   * threshold are filtered out before the response is built.
+   *
+   * Use cases:
+   * - Drop low-confidence hits when bandwidth is precious (mobile MCP
+   *   clients, summarisation pipelines).
+   * - Pin a quality bar for downstream consumers that cannot easily
+   *   filter on their side.
+   *
+   * Notes:
+   * - The filter runs AFTER scoring and ranking; `total_candidates`
+   *   still reflects the pre-filter pool so the caller can detect
+   *   "found 12 candidates, kept 3 above threshold".
+   * - When `min_score` is omitted, no filter is applied (the previous
+   *   behaviour).
+   */
+  min_score?: number | undefined;
 }
 
 export interface RecallOutputWire {

--- a/code/src/modules/mcp-server/infrastructure/validation/recall-schema.ts
+++ b/code/src/modules/mcp-server/infrastructure/validation/recall-schema.ts
@@ -34,6 +34,10 @@ export const RecallInputSchema = z
     scope: z.enum(["project", "module"]).optional(),
     module: z.string().min(1).optional(),
     include_superseded: z.boolean().optional(),
+    // Optional minimum relevance threshold for the final score.
+    // Applied AFTER ranking; `total_candidates` reflects the
+    // pre-filter pool so callers can detect aggressive thresholds.
+    min_score: z.number().min(0).max(1).optional(),
   })
   .strict();
 

--- a/code/tests/integration/D-mem-recall.test.ts
+++ b/code/tests/integration/D-mem-recall.test.ts
@@ -207,4 +207,56 @@ describe("integration / D / mem.recall — hybrid retrieval", () => {
       expect(typeof r.created_at).toBe("number");
     }
   });
+
+  // B-MCP-5: post-hoc `min_score` threshold trims low-confidence
+  // hits without affecting `total_candidates`. The contract:
+  //   1. `min_score=0` is a no-op (same length as baseline).
+  //   2. Every survivor under any threshold has `score >= threshold`.
+  //   3. The filtered length is monotonically non-increasing as the
+  //      threshold rises.
+  //   4. `total_candidates` reflects the PRE-filter pool — it stays
+  //      constant even when the survivor list shrinks.
+  it("via wire facade — `min_score` filters results without changing total_candidates", async () => {
+    const baseline = await ctx.mcpServer.useCases.recall.recall({
+      workspace_id: ctx.workspaceId.toString(),
+      query: "hexagonal",
+      top_k: 5,
+      max_tokens: 2000,
+    });
+    expect(baseline.results.length).toBeGreaterThan(0);
+    const baselineCandidates = baseline.total_candidates;
+
+    // (1) Threshold of zero → identical to omitting the filter.
+    const allowAll = await ctx.mcpServer.useCases.recall.recall({
+      workspace_id: ctx.workspaceId.toString(),
+      query: "hexagonal",
+      top_k: 5,
+      max_tokens: 2000,
+      min_score: 0,
+    });
+    expect(allowAll.results).toHaveLength(baseline.results.length);
+    expect(allowAll.total_candidates).toBe(baselineCandidates);
+
+    // (2) + (3) + (4): pick a threshold at the median baseline score.
+    // Every survivor must be at or above it; the count must not grow;
+    // the candidate pool must be unchanged.
+    const sortedScores = [...baseline.results.map((r) => r.score)].sort(
+      (a, b) => a - b,
+    );
+    const median = sortedScores[Math.floor(sortedScores.length / 2)] ?? 0;
+    const filtered = await ctx.mcpServer.useCases.recall.recall({
+      workspace_id: ctx.workspaceId.toString(),
+      query: "hexagonal",
+      top_k: 5,
+      max_tokens: 2000,
+      min_score: median,
+    });
+    expect(filtered.total_candidates).toBe(baselineCandidates);
+    expect(filtered.results.length).toBeLessThanOrEqual(
+      baseline.results.length,
+    );
+    for (const r of filtered.results) {
+      expect(r.score).toBeGreaterThanOrEqual(median);
+    }
+  });
 });

--- a/code/tests/unit/mcp-server/infrastructure/schemas.test.ts
+++ b/code/tests/unit/mcp-server/infrastructure/schemas.test.ts
@@ -112,6 +112,34 @@ describe("RecallInputSchema", () => {
       false,
     );
   });
+
+  // B-MCP-5: min_score is the post-hoc relevance threshold applied
+  // by the facade after ranking. Range is [0, 1]; out-of-range
+  // values must be rejected at the wire boundary so the facade can
+  // assume valid input.
+  it("accepts min_score within [0, 1]", () => {
+    for (const v of [0, 0.5, 1]) {
+      expect(RecallInputSchema.safeParse({ min_score: v }).success).toBe(true);
+    }
+  });
+
+  it("rejects min_score below 0", () => {
+    expect(
+      RecallInputSchema.safeParse({ min_score: -0.0001 }).success,
+    ).toBe(false);
+  });
+
+  it("rejects min_score above 1", () => {
+    expect(
+      RecallInputSchema.safeParse({ min_score: 1.0001 }).success,
+    ).toBe(false);
+  });
+
+  it("accepts query + min_score in the same call", () => {
+    expect(
+      RecallInputSchema.safeParse({ query: "x", min_score: 0.7 }).success,
+    ).toBe(true);
+  });
 });
 
 describe("RememberInputSchema", () => {

--- a/docs/02-protocolo-mcp.md
+++ b/docs/02-protocolo-mcp.md
@@ -185,10 +185,19 @@ Busqueda flexible. Reemplaza `recall_relevant` + `recall_by_kind` +
   scope?: "project" | "module";
   module?: string;
   include_superseded?: boolean;      // default false
+  min_score?: number;                // 0..1; filtra entries cuyo score final sea < threshold (post-hoc)
 }
 
 type Kind = "decision" | "learning" | "turn" | "entity" | "task" | "any";
 ```
+
+**Notas sobre `min_score`:**
+- Rango `[0, 1]`. Validado por Zod; valores fuera de rango devuelven
+  `-32602 INVALID_PARAMS`.
+- Aplicado **despues** del scoring y ranking. `total_candidates` sigue
+  reflejando el pool completo PRE-filtro, asi el cliente detecta
+  thresholds demasiado agresivos ("12 candidatos, 3 sobre threshold").
+- Si se omite, no se aplica filtro (comportamiento original).
 
 **Output:**
 ```typescript


### PR DESCRIPTION
## Que cambia

`mem.recall` acepta `min_score?: number` (0..1) que filtra post-hoc
los resultados con score < threshold. Cierra issue #4.

## Por que

Fixes #4. Investigacion mostro que la premisa del issue era
ligeramente incorrecta (docs/02 §4.3 no menciona min_score; §4.4 es
mem.remember), pero la expectativa del usuario es razonable y util:
permite filtrar hits de baja confianza en banda angosta sin un
follow-up. Optamos por implementar antes que cerrar como no-op.

## Tipo de cambio

- [x] feat — nueva funcionalidad
- [x] docs — actualiza docs/02 §4.3
- [x] test — agrega tests

## Checklist

- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` y `npm run lint:tests` EXIT=0
- [x] `npm run validate:modules` EXIT=0
- [x] `npm run build` EXIT=0
- [x] `npm run test` EXIT=0 — **2512 tests passing en 207 archivos** (was 2507)
- [x] Cero `any`, cero `as any`, cero `// @ts-ignore`
- [x] Tests nuevos cubren el cambio
- [x] Wire/protocolo MCP documentado en `docs/02 §4.3`
- [ ] N/A — no introduce ADR

## E2E que validan VALORES

- [x] Los tests asertan valores reales (no solo shape)

`tests/integration/D-mem-recall.test.ts` (+1 caso) valida 4
contratos:

1. `min_score=0` es no-op (mismo length que baseline).
2. `total_candidates` no cambia entre llamadas — refleja el pool
   pre-filtro siempre.
3. Threshold = mediana de scores baseline → length filtrado <=
   length baseline.
4. Cada sobreviviente tiene `score >= threshold`.

`schemas.test.ts` (+4 casos) valida el rango `[0, 1]` y rechaza
out-of-range.

## Notas para el reviewer

**Decisiones de diseno**:

- **Post-hoc en el facade, no en el use case**: el threshold es una
  preocupacion de wire (depende del scoring final del lado del
  usuario). El use case retrieval no necesita conocerlo. La aplicacion
  ocurre en `RecallMemoryFacadeAdapter` justo antes de armar la
  response. Mantiene la frontera entre dominio (scoring + ranking) y
  presentacion (recorte por umbral).
- **`total_candidates` sigue reflejando el pool pre-filtro**: asi
  el cliente detecta thresholds demasiado agresivos
  ("encontre 12, deje pasar 3"). Comportamiento estandar en API de
  busqueda con thresholds.
- **Rango validado en Zod**: `[0, 1]`. Mantiene la frontera defensiva
  donde corresponde.