### PR TITLE
fix(memory): persist decision content (B-MCP-4 critical data loss)

### DIFF
--- a/code/migrations/008__decisions-content.sql
+++ b/code/migrations/008__decisions-content.sql
@@ -1,0 +1,118 @@
+-- ─────────────────────────────────────────────────────────────────────
+-- 008__decisions-content.sql
+--
+-- Bug B-MCP-4 fix (issue #3, critical, data loss).
+--
+-- Background: the wire schema in `docs/02-protocolo-mcp.md §4.4`
+-- documents `content: string` as the canonical full-text field for
+-- every `mem.remember` kind. The `decisions` table created in
+-- migration 004 had no `content` column, so the field was silently
+-- dropped during persistence. Clients that supplied both
+-- `content` and `rationale` lost the former without any error.
+--
+-- Decision: Option B from the ADR — preserve the documented wire
+-- contract and add the column. Stability of the public protocol
+-- outweighs the cost of a one-time schema migration on existing
+-- workspaces.
+--
+-- This migration:
+--   1. Adds `content TEXT NOT NULL DEFAULT ''` to the `decisions`
+--      base table. The default keeps NOT NULL semantics tractable
+--      for SQLite's restricted ALTER TABLE.
+--   2. Backfills existing rows with `content = rationale`. We choose
+--      `rationale` rather than the empty string because:
+--        - rationale is the closest semantic neighbour and was the
+--          best available substitute that the v0.1.0/v0.1.1 facade
+--          actually persisted (`rationale: input.rationale ?? input.content`);
+--        - empty content would defeat the recall path's preview/FTS
+--          for every existing row, breaking searches against
+--          dogfood data;
+--        - the domain VO (`DecisionContent`) requires a non-empty
+--          string; backfilling with rationale keeps rehydration
+--          well-formed across the boundary.
+--   3. Replaces the `decisions_fts` virtual table to include the
+--      `content` column. FTS5 with external content (`content='decisions'`)
+--      requires the FTS column names to match the base table; the
+--      virtual table cannot be ALTERed in place, so we drop and
+--      recreate.
+--   4. Repopulates the new FTS index from the now-backfilled base
+--      table.
+--   5. Replaces the `decisions_ai`, `decisions_ad`, and `decisions_au`
+--      triggers to keep the FTS mirror in sync with the new column.
+--
+-- Owner: `memory-domain` (aggregate change), `composition` (wiring).
+-- Idempotency: SQLite's `ADD COLUMN` is one-shot, so this migration
+-- relies on the migrations runner's `_meta`-based "applied versions"
+-- bookkeeping. Re-running on an already-migrated workspace would
+-- fail at step 1; the runner skips applied versions by design.
+-- ─────────────────────────────────────────────────────────────────────
+
+
+-- ── 1. base table column ─────────────────────────────────────────────
+ALTER TABLE decisions ADD COLUMN content TEXT NOT NULL DEFAULT '';
+
+
+-- ── 2. backfill ──────────────────────────────────────────────────────
+-- Existing rows inherited from v0.1.x wire calls have `rationale` set
+-- (it was the field the facade persisted). Copy it into the new
+-- `content` slot so:
+--   (a) `DecisionContent` rehydration succeeds for every row;
+--   (b) FTS5 keeps producing hits for legacy rows after the index
+--       rebuild below.
+UPDATE decisions
+   SET content = rationale
+ WHERE content = '';
+
+
+-- ── 3. drop the obsolete FTS5 virtual table ──────────────────────────
+-- DROP TABLE on an FTS5 virtual table also removes the auxiliary
+-- shadow tables (`decisions_fts_data`, `_idx`, `_docsize`,
+-- `_config`).
+DROP TABLE IF EXISTS decisions_fts;
+
+
+-- ── 4. recreate with the `content` column added ──────────────────────
+-- Mirrors `004 §3` plus the new column. `content='decisions'` keeps
+-- the external-content layout — the FTS5 row is a search index over
+-- the base row, no duplication on disk.
+CREATE VIRTUAL TABLE decisions_fts USING fts5(
+    id      UNINDEXED,
+    title,
+    rationale,
+    content,
+    content='decisions'
+);
+
+
+-- ── 5. rebuild the FTS index from the base table ─────────────────────
+-- `INSERT INTO <fts5> SELECT ...` re-tokenises every base row.
+INSERT INTO decisions_fts (id, title, rationale, content)
+SELECT id, title, rationale, content FROM decisions;
+
+
+-- ── 6. replace triggers ──────────────────────────────────────────────
+DROP TRIGGER IF EXISTS decisions_ai;
+DROP TRIGGER IF EXISTS decisions_ad;
+DROP TRIGGER IF EXISTS decisions_au;
+
+CREATE TRIGGER decisions_ai AFTER INSERT ON decisions BEGIN
+    INSERT INTO decisions_fts (id, title, rationale, content)
+    VALUES (new.id, new.title, new.rationale, new.content);
+END;
+
+CREATE TRIGGER decisions_ad AFTER DELETE ON decisions BEGIN
+    DELETE FROM decisions_fts WHERE id = old.id;
+END;
+
+-- Migration 007's column-scoped UPDATE OF rule preserves the
+-- "skip FTS when only confidence/use_count/last_used_ms changes"
+-- optimisation; carrying it forward as we add `content` to the
+-- watched-columns list.
+CREATE TRIGGER decisions_au
+AFTER UPDATE OF title, rationale, content ON decisions BEGIN
+    UPDATE decisions_fts
+        SET title     = new.title,
+            rationale = new.rationale,
+            content   = new.content
+        WHERE id = new.id;
+END;

--- a/code/src/composition/facades/mcp-server-facades.ts
+++ b/code/src/composition/facades/mcp-server-facades.ts
@@ -448,6 +448,12 @@ export class RememberFacadeAdapter implements RememberFacade {
           sessionId: null,
           title: input.title ?? deriveTitleFromContent(input.content),
           rationale: input.rationale ?? input.content,
+          // B-MCP-4 fix (issue #3): always pass `content` through to
+          // the aggregate so the long-form body is persisted in the
+          // new `decisions.content` column. Previously the field was
+          // silently dropped — clients lost data when supplying both
+          // rationale and content.
+          content: input.content,
           tags,
           scope,
         });

--- a/code/src/modules/memory/application/ports/in/record-decision.port.ts
+++ b/code/src/modules/memory/application/ports/in/record-decision.port.ts
@@ -54,6 +54,14 @@ export interface RecordDecision {
     sessionId: SessionId | null;
     title: string;
     rationale: string;
+    /**
+     * Long-form body of the decision. Mirrors the wire `content`
+     * field (`docs/02 §4.4`) introduced into the `decisions.content`
+     * column by migration 008 (B-MCP-4 / issue #3). When absent the
+     * use case falls back to `rationale` so the persisted column
+     * stays non-empty.
+     */
+    content?: string;
     tags: Tags;
     scope: Scope;
   }): Promise<RecordDecisionResult>;

--- a/code/src/modules/memory/application/use-cases/import-handoff.use-case.ts
+++ b/code/src/modules/memory/application/use-cases/import-handoff.use-case.ts
@@ -16,6 +16,7 @@ import { EmbeddingStatus } from "../../domain/value-objects/embedding-status.ts"
 import { LearningId } from "../../domain/value-objects/learning-id.ts";
 import { LearningSeverity } from "../../domain/value-objects/learning-severity.ts";
 import { LearningText } from "../../domain/value-objects/learning-text.ts";
+import { DecisionContent } from "../../domain/value-objects/decision-content.ts";
 import { Rationale } from "../../domain/value-objects/rationale.ts";
 import { Scope } from "../../domain/value-objects/scope.ts";
 import { TaskDescription } from "../../domain/value-objects/task-description.ts";
@@ -92,6 +93,10 @@ export class ImportHandoffUseCase implements ImportHandoff {
         sessionId: null,
         title: DecisionTitle.from(d.title),
         rationale: Rationale.from(d.rationale),
+        // Handoff parser predates the `content` column (B-MCP-4 fix);
+        // reuse rationale as the long-form body so the rehydration
+        // path stays well-formed.
+        content: DecisionContent.from(d.rationale),
         tags: d.tags,
         confidence: Confidence.of(d.confidence),
         scope: projectScope,

--- a/code/src/modules/memory/application/use-cases/record-decision.use-case.ts
+++ b/code/src/modules/memory/application/use-cases/record-decision.use-case.ts
@@ -7,6 +7,7 @@ import type { WorkspaceId } from "../../../../shared/domain/value-objects/worksp
 import { Confidence } from "../../../../shared/domain/value-objects/confidence.ts";
 import { Decision } from "../../domain/aggregates/decision.ts";
 import type { DecisionRepository } from "../../domain/repositories/decision-repository.ts";
+import { DecisionContent } from "../../domain/value-objects/decision-content.ts";
 import { DecisionId } from "../../domain/value-objects/decision-id.ts";
 import { DecisionTitle } from "../../domain/value-objects/decision-title.ts";
 import { EmbeddingStatus } from "../../domain/value-objects/embedding-status.ts";
@@ -68,17 +69,28 @@ export class RecordDecisionUseCase implements RecordDecision {
     sessionId: SessionId | null;
     title: string;
     rationale: string;
+    /**
+     * Long-form body for the decision. Wire callers always supply
+     * this (the Zod schema requires `content: z.string().min(1)`).
+     * When the caller omits it (e.g. internal workflows that build
+     * a decision from a CLI prompt), the use case falls back to
+     * `rationale` so the persisted column is never empty (Bug
+     * B-MCP-4 / issue #3, Option B).
+     */
+    content?: string;
     tags: Tags;
     scope: Scope;
   }): Promise<RecordDecisionResult> {
     const now = this.clock.now();
     const decisionId = DecisionId.from(this.idGen.generateString());
+    const contentRaw = input.content ?? input.rationale;
     const decision = Decision.record({
       id: decisionId,
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
       title: DecisionTitle.from(input.title),
       rationale: Rationale.from(input.rationale),
+      content: DecisionContent.from(contentRaw),
       tags: input.tags,
       confidence: Confidence.full(),
       scope: input.scope,

--- a/code/src/modules/memory/domain/aggregates/decision.ts
+++ b/code/src/modules/memory/domain/aggregates/decision.ts
@@ -8,6 +8,7 @@ import { DecisionSelfSupersessionError } from "../errors/decision-self-supersess
 import { DecisionRecorded } from "../events/decision-recorded.ts";
 import { DecisionSuperseded } from "../events/decision-superseded.ts";
 import { DecisionUsed } from "../events/decision-used.ts";
+import type { DecisionContent } from "../value-objects/decision-content.ts";
 import type { DecisionId } from "../value-objects/decision-id.ts";
 import { DecisionStatus } from "../value-objects/decision-status.ts";
 import type { DecisionTitle } from "../value-objects/decision-title.ts";
@@ -64,6 +65,22 @@ export class Decision {
   private readonly sessionId: SessionId | null;
   private readonly title: DecisionTitle;
   private readonly rationale: Rationale;
+  /**
+   * Long-form body of the decision. Mirrors `decisions.content` as
+   * added by migration `008__decisions-content.sql`. The wire schema
+   * (`docs/02 §4.4`) has always required this field; the original
+   * schema lacked the column and the facade silently dropped it
+   * (Bug B-MCP-4 / issue #3). Now persisted verbatim, recall returns
+   * it intact in the wire response.
+   *
+   * Relationship with `rationale`:
+   * - `rationale` is the SHORT WHY (capped 5,000 chars).
+   * - `content` is the LONG BODY (capped 50,000 chars).
+   * - When the wire client supplies only `rationale`, the facade
+   *   reuses it as content; the aggregate sees both fields populated
+   *   either way.
+   */
+  private readonly content: DecisionContent;
   private readonly tags: Tags;
   private status: DecisionStatus;
   private supersededBy: SupersededBy | null;
@@ -82,6 +99,7 @@ export class Decision {
     sessionId: SessionId | null;
     title: DecisionTitle;
     rationale: Rationale;
+    content: DecisionContent;
     tags: Tags;
     status: DecisionStatus;
     supersededBy: SupersededBy | null;
@@ -99,6 +117,7 @@ export class Decision {
     this.sessionId = input.sessionId;
     this.title = input.title;
     this.rationale = input.rationale;
+    this.content = input.content;
     this.tags = input.tags;
     this.status = input.status;
     this.supersededBy = input.supersededBy;
@@ -136,6 +155,7 @@ export class Decision {
     sessionId: SessionId | null;
     title: DecisionTitle;
     rationale: Rationale;
+    content: DecisionContent;
     tags: Tags;
     confidence: Confidence;
     scope: Scope;
@@ -153,6 +173,7 @@ export class Decision {
       sessionId: input.sessionId,
       title: input.title,
       rationale: input.rationale,
+      content: input.content,
       tags: input.tags,
       status: DecisionStatus.active(),
       supersededBy: null,
@@ -177,6 +198,7 @@ export class Decision {
     sessionId: SessionId | null;
     title: DecisionTitle;
     rationale: Rationale;
+    content: DecisionContent;
     tags: Tags;
     status: DecisionStatus;
     supersededBy: SupersededBy | null;
@@ -194,6 +216,7 @@ export class Decision {
       sessionId: input.sessionId,
       title: input.title,
       rationale: input.rationale,
+      content: input.content,
       tags: input.tags,
       status: input.status,
       supersededBy: input.supersededBy,
@@ -284,6 +307,10 @@ export class Decision {
 
   public getRationale(): Rationale {
     return this.rationale;
+  }
+
+  public getContent(): DecisionContent {
+    return this.content;
   }
 
   public getTags(): Tags {

--- a/code/src/modules/memory/domain/value-objects/decision-content.ts
+++ b/code/src/modules/memory/domain/value-objects/decision-content.ts
@@ -1,0 +1,66 @@
+import { InvalidInputError } from "../../../../shared/domain/errors/invalid-input-error.ts";
+import { NonEmptyString } from "../../../../shared/domain/value-objects/non-empty-string.ts";
+
+/**
+ * Maximum length, in characters, of a decision's `content` body.
+ *
+ * Where this comes from:
+ *   - `docs/02-protocolo-mcp.md §4.4` documents `content: string` as
+ *     the canonical full-text field for `mem.remember`. The protocol
+ *     does not pin a cap.
+ *   - The retrieval bundle (`docs/04-capas-contexto.md §3.2`)
+ *     pre-allocates per-entry token budgets — at worst-case 4 chars
+ *     per token, 50,000 chars ≈ 12.5K tokens, which still fits inside
+ *     a single recall envelope's budget without forcing the bundle
+ *     planner to truncate aggressively.
+ *   - Decisions occasionally carry long-form rationale plus context
+ *     ("ADR-style" entries are common in real workspaces); 50,000
+ *     leaves room for an ADR full body without artificially clipping
+ *     legitimate inputs.
+ *
+ * The cap is well above `Rationale`'s 5,000 because `content` is
+ * explicitly the "long-form" field — short-form lives in `rationale`.
+ */
+const MAX_CONTENT_LENGTH = 50_000;
+
+/**
+ * Value object for the canonical `content` body of a `Decision`.
+ *
+ * Mirrors `decisions.content TEXT NOT NULL` as added by migration
+ * `008__decisions-content.sql`. The wire schema (`docs/02 §4.4`)
+ * has always required this field for every `mem.remember` kind, but
+ * the original schema lacked the column and the facade silently
+ * dropped the value (Bug B-MCP-4 / issue #3). Adding the VO closes
+ * the loop on the domain side.
+ *
+ * Invariants (in addition to {@link NonEmptyString}'s):
+ * - The trimmed content is at most {@link MAX_CONTENT_LENGTH}
+ *   characters. Inputs above the cap raise {@link InvalidInputError}
+ *   with a precise length-mismatch message so the wire boundary can
+ *   surface a structured -32602 error.
+ * - Newlines are allowed — long-form decision bodies routinely span
+ *   paragraphs and bullet lists.
+ *
+ * Relationship with `Rationale`:
+ * - `Rationale` is the SHORT WHY (the justification, capped at 5,000
+ *   chars).
+ * - `DecisionContent` is the LONG BODY (the full text the client
+ *   wants to persist verbatim, capped at 50,000 chars).
+ * - When the wire client supplies only one of the two, the facade
+ *   falls back: missing `content` → reuses `rationale`; missing
+ *   `rationale` → derives a one-line summary from `content`. The VO
+ *   layer is unaware of those fallbacks — it sees only well-formed,
+ *   non-empty strings.
+ */
+export class DecisionContent extends NonEmptyString {
+  public static from(raw: string): DecisionContent {
+    const trimmed = NonEmptyString.normalize(raw, "content");
+    if (trimmed.length > MAX_CONTENT_LENGTH) {
+      throw new InvalidInputError(
+        `decision content must be at most ${String(MAX_CONTENT_LENGTH)} characters (got: ${String(trimmed.length)})`,
+        { field: "content" },
+      );
+    }
+    return new DecisionContent(trimmed);
+  }
+}

--- a/code/src/modules/memory/infrastructure/import-export/json-memory-exporter.ts
+++ b/code/src/modules/memory/infrastructure/import-export/json-memory-exporter.ts
@@ -66,6 +66,9 @@ export class JsonMemoryExporter implements MemoryExporter {
       id: d.getId().toString(),
       title: d.getTitle().toString(),
       rationale: d.getRationale().toString(),
+      // Migration 008 (B-MCP-4) added the canonical long-form body.
+      // Surfacing it here keeps round-trip exports/imports lossless.
+      content: d.getContent().toString(),
       tags: d.getTags().toArray(),
       status: d.getStatus().toString(),
       supersededBy: d.getSupersededBy()?.decisionId.toString() ?? null,

--- a/code/src/modules/memory/infrastructure/import-export/json-memory-importer.ts
+++ b/code/src/modules/memory/infrastructure/import-export/json-memory-importer.ts
@@ -32,6 +32,7 @@ import { LearningText } from "../../domain/value-objects/learning-text.ts";
 import { LinkedDecisionIds } from "../../domain/value-objects/linked-decision-ids.ts";
 import { LinkedLearningIds } from "../../domain/value-objects/linked-learning-ids.ts";
 import { OpenQuestion } from "../../domain/value-objects/open-question.ts";
+import { DecisionContent } from "../../domain/value-objects/decision-content.ts";
 import { Rationale } from "../../domain/value-objects/rationale.ts";
 import { RelationEndpoint } from "../../domain/value-objects/relation-endpoint.ts";
 import { RelationId } from "../../domain/value-objects/relation-id.ts";
@@ -69,6 +70,10 @@ const DecisionSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
   rationale: z.string(),
+  // Optional in the import schema for backward compat with v0.1.0/0.1.1
+  // exports that predate the `content` column (B-MCP-4). When absent,
+  // `buildDecision` falls back to `rationale`.
+  content: z.string().optional(),
   tags: z.array(z.string().min(1)),
   status: z.string().min(1),
   supersededBy: z.string().nullable(),
@@ -269,6 +274,9 @@ export class JsonMemoryImporter implements MemoryImporter {
       sessionId: null,
       title: DecisionTitle.from(d.title),
       rationale: Rationale.from(d.rationale),
+      // Legacy exports (pre-B-MCP-4) lack `content`; fall back to
+      // rationale so the rehydration preserves the searchable text.
+      content: DecisionContent.from(d.content ?? d.rationale),
       tags: this.buildTags(d.tags),
       status: DecisionStatus.create(d.status),
       supersededBy:

--- a/code/src/modules/memory/infrastructure/persistence/sqlite-decision-repository.ts
+++ b/code/src/modules/memory/infrastructure/persistence/sqlite-decision-repository.ts
@@ -7,6 +7,7 @@ import { Timestamp } from "../../../../shared/domain/value-objects/timestamp.ts"
 import type { WorkspaceId } from "../../../../shared/domain/value-objects/workspace-id.ts";
 import { Decision } from "../../domain/aggregates/decision.ts";
 import type { DecisionRepository } from "../../domain/repositories/decision-repository.ts";
+import { DecisionContent } from "../../domain/value-objects/decision-content.ts";
 import { DecisionId } from "../../domain/value-objects/decision-id.ts";
 import { DecisionStatus } from "../../domain/value-objects/decision-status.ts";
 import { DecisionTitle } from "../../domain/value-objects/decision-title.ts";
@@ -31,6 +32,10 @@ const DecisionRowSchema = z.object({
   created_at_ms: z.number().int().min(0),
   title: z.string().min(1),
   rationale: z.string(),
+  // Migration 008 (B-MCP-4) added this column. Existing rows were
+  // backfilled with `rationale`, so the read path always sees a
+  // non-empty string here on a properly-migrated database.
+  content: z.string(),
   scope: z.string().min(1),
   module: z.string().nullable(),
   superseded_by: z.string().nullable(),
@@ -44,12 +49,13 @@ const TagsArraySchema = z.array(z.string().min(1));
 
 const SQL_UPSERT = `
 INSERT INTO decisions (
-  id, created_at_ms, title, rationale, alternatives_rejected,
+  id, created_at_ms, title, rationale, content, alternatives_rejected,
   scope, module, superseded_by, confidence, last_used_ms, use_count, tags_json
-) VALUES (?, ?, ?, ?, '[]', ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, '[]', ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
   title          = excluded.title,
   rationale      = excluded.rationale,
+  content        = excluded.content,
   scope          = excluded.scope,
   module         = excluded.module,
   superseded_by  = excluded.superseded_by,
@@ -60,7 +66,7 @@ ON CONFLICT(id) DO UPDATE SET
 `.trim();
 
 const SQL_SELECT_BY_ID = `
-SELECT id, created_at_ms, title, rationale, scope, module,
+SELECT id, created_at_ms, title, rationale, content, scope, module,
        superseded_by, confidence, last_used_ms, use_count, tags_json
 FROM decisions
 WHERE id = ?
@@ -68,14 +74,14 @@ LIMIT 1
 `.trim();
 
 const SQL_SELECT_ALL = `
-SELECT id, created_at_ms, title, rationale, scope, module,
+SELECT id, created_at_ms, title, rationale, content, scope, module,
        superseded_by, confidence, last_used_ms, use_count, tags_json
 FROM decisions
 ORDER BY created_at_ms DESC, id DESC
 `.trim();
 
 const SQL_SELECT_BY_STATUS_ACTIVE = `
-SELECT id, created_at_ms, title, rationale, scope, module,
+SELECT id, created_at_ms, title, rationale, content, scope, module,
        superseded_by, confidence, last_used_ms, use_count, tags_json
 FROM decisions
 WHERE superseded_by IS NULL
@@ -83,7 +89,7 @@ ORDER BY created_at_ms DESC, id DESC
 `.trim();
 
 const SQL_SELECT_BY_STATUS_SUPERSEDED = `
-SELECT id, created_at_ms, title, rationale, scope, module,
+SELECT id, created_at_ms, title, rationale, content, scope, module,
        superseded_by, confidence, last_used_ms, use_count, tags_json
 FROM decisions
 WHERE superseded_by IS NOT NULL
@@ -154,6 +160,7 @@ export class SqliteDecisionRepository implements DecisionRepository {
         decision.getCreatedAt().toEpochMs(),
         decision.getTitle().toString(),
         decision.getRationale().toString(),
+        decision.getContent().toString(),
         decision.getScope().kind,
         moduleValue,
         supersededByValue,
@@ -266,6 +273,10 @@ export class SqliteDecisionRepository implements DecisionRepository {
       sessionId: null,
       title: DecisionTitle.from(parsed.title),
       rationale: Rationale.from(parsed.rationale),
+      // Migration 008 backfilled `content` from `rationale` for legacy
+      // rows; new rows always carry the wire content. Either way the
+      // VO's non-empty invariant holds at the boundary.
+      content: DecisionContent.from(parsed.content),
       tags,
       status,
       supersededBy,

--- a/code/src/modules/retrieval/infrastructure/persistence/sqlite-memory-projection-repository.ts
+++ b/code/src/modules/retrieval/infrastructure/persistence/sqlite-memory-projection-repository.ts
@@ -46,6 +46,11 @@ const DecisionRowSchema = z.object({
   id: z.string(),
   title: z.string(),
   rationale: z.string(),
+  // B-MCP-4: migration 008 added this column. Optional in the schema
+  // because legacy snapshots from before the migration may still be
+  // around in tests; the load path falls back to rationale when
+  // absent so the preview never goes empty.
+  content: z.string().optional(),
   scope: z.string(),
   module: z.string().nullable(),
   confidence: z.number(),
@@ -124,7 +129,7 @@ const SessionRowSchema = z.object({
 // ─── SQL ───────────────────────────────────────────────────────────────
 
 const SQL_LIST_ACTIVE_DECISIONS = `
-SELECT id, title, rationale, scope, module, confidence,
+SELECT id, title, rationale, content, scope, module, confidence,
        last_used_ms, use_count, tags_json, created_at_ms
 FROM decisions
 WHERE superseded_by IS NULL
@@ -498,7 +503,7 @@ WHERE id IN (${placeholders})
   private loadDecisions(ids: readonly string[], out: MemoryProjection[]): void {
     const placeholders = ids.map(() => "?").join(", ");
     const sql = `
-SELECT id, title, rationale, scope, module, confidence,
+SELECT id, title, rationale, content, scope, module, confidence,
        last_used_ms, use_count, tags_json, created_at_ms
 FROM decisions
 WHERE id IN (${placeholders})
@@ -511,7 +516,12 @@ WHERE id IN (${placeholders})
         kind: "decision",
         id: parsed.id,
         title: parsed.title,
-        preview: truncatePreview(parsed.rationale),
+        // B-MCP-4 (issue #3): the wire `content` field now reflects the
+        // full body the client supplied to `mem.remember`. Pre-migration
+        // rows fall back to `rationale` (which migration 008 also
+        // copied into `content` during backfill, so the two paths
+        // converge for legacy data).
+        preview: truncatePreview(parsed.content ?? parsed.rationale),
         tags: parseTags(parsed.tags_json),
         confidence: Confidence.of(parsed.confidence),
         useCount: UseCount.of(parsed.use_count),

--- a/code/tests/_fixtures/memory-database.ts
+++ b/code/tests/_fixtures/memory-database.ts
@@ -12,6 +12,8 @@
  *                                   learnings, entities, relations,
  *                                   tasks + their FTS5 shadows)
  *   - 005__perf-indexes.sql        (post-release perf indexes)
+ *   - 008__decisions-content.sql   (B-MCP-4: adds `decisions.content`
+ *                                   + rebuilds the FTS5 index over it)
  *
  * The `embedding_queue` table from migration 002 is created in a
  * minimal stub form so the `SqliteEmbeddingEnqueuer` adapter can
@@ -85,6 +87,7 @@ const REQUIRED_MIGRATIONS: readonly string[] = Object.freeze([
   "000__bootstrap.sql",
   "004__core-memory-schema.sql",
   "005__perf-indexes.sql",
+  "008__decisions-content.sql",
 ]);
 
 /**

--- a/code/tests/integration/N-decision-content-roundtrip.test.ts
+++ b/code/tests/integration/N-decision-content-roundtrip.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration test — Flow N: `mem.remember(kind=decision)` content
+ * round-trips through SQL and back through `mem.recall`.
+ *
+ * Regression for Bug B-MCP-4 (https://github.com/NetziTech/recall/issues/3):
+ * the `decisions` table had no `content` column, so the canonical
+ * full-text body documented in `docs/02 §4.4` was silently dropped
+ * during persistence. Migration 008 added the column, the aggregate
+ * carries it, and the recall projection surfaces it back to wire.
+ *
+ * Methodology — VALUES, not SHAPE (Phase-9 lesson):
+ *   1. Establish known state: workspace has zero decisions.
+ *   2. Invoke `mem.remember` (the wire facade) with kind=decision,
+ *      a SHORT rationale, and a LONG content paragraph distinct from
+ *      the rationale. The two strings must NOT contain the same
+ *      tokens so we can prove which one came back later.
+ *   3. Inspect the SQL row directly: the `content` column must equal
+ *      the long body, and the `rationale` column must equal the
+ *      short rationale.
+ *   4. Issue `mem.recall` for a token that appears ONLY in `content`
+ *      (not in title or rationale). The hit must come back, and the
+ *      wire `content` field of the response must equal the long
+ *      content body — not the rationale (the pre-fix behaviour).
+ *
+ * Why this catches B-MCP-4: the test is built around the exact
+ * sentence pairs that the v0.1.x behaviour confused — a rationale
+ * that DIFFERS from the content. The pre-fix code path stored
+ * rationale and returned rationale-as-content; this test asserts that
+ * the post-fix code stores AND returns the actual content.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Tags } from "../../src/shared/domain/value-objects/tags.ts";
+import { Scope } from "../../src/modules/memory/domain/value-objects/scope.ts";
+import {
+  buildTestContainer,
+  type TestContainer,
+} from "./_helpers/build-test-container.ts";
+
+const RATIONALE = "Choose SQLite for portability";
+const CONTENT_BODY =
+  "The team evaluated PostgreSQL, DuckDB, and SQLite. The deciding factor was the file-per-workspace deployment model that keeps the memory binary self-contained without a server process. The hexagonal architecture lets us swap engines later if a benchmark forces the choice.";
+
+describe("integration / N / mem.remember(decision) content round-trips (B-MCP-4)", () => {
+  let ctx: TestContainer;
+
+  beforeEach(async () => {
+    ctx = await buildTestContainer();
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("persists `content` to the SQL column and surfaces it back through recall", async () => {
+    const remember = await ctx.mcpServer.useCases.remember.remember({
+      workspace_id: ctx.workspaceId.toString(),
+      kind: "decision",
+      title: "Pick SQLite",
+      rationale: RATIONALE,
+      content: CONTENT_BODY,
+      tags: ["persistence", "decision"],
+    });
+    expect(remember.id.length).toBeGreaterThan(0);
+
+    // ── SQL inspection: the content column must hold the long body,
+    //    NOT the rationale (the v0.1.x silent-drop behaviour).
+    const row = ctx.database
+      .prepare("SELECT title, rationale, content FROM decisions WHERE id = ?")
+      .get(remember.id) as
+      | { readonly title: string; readonly rationale: string; readonly content: string }
+      | undefined;
+    expect(row).toBeDefined();
+    expect(row?.title).toBe("Pick SQLite");
+    expect(row?.rationale).toBe(RATIONALE);
+    expect(row?.content).toBe(CONTENT_BODY);
+    // Sanity check: rationale and content are intentionally different
+    // so the assertion above is meaningful.
+    expect(row?.content).not.toBe(row?.rationale);
+
+    // ── Wire round-trip: recall a token that only appears in `content`
+    //    (not in title or rationale). Pre-fix this returned zero hits
+    //    because the content was never persisted — the FTS index only
+    //    contained title + rationale. Migration 008 rebuilt the FTS
+    //    index over content, so the token now matches.
+    const recall = await ctx.mcpServer.useCases.recall.recall({
+      workspace_id: ctx.workspaceId.toString(),
+      query: "PostgreSQL DuckDB",
+      top_k: 5,
+      max_tokens: 4000,
+    });
+    expect(recall.results.length).toBeGreaterThan(0);
+    const hit = recall.results.find((r) => r.id === remember.id);
+    expect(hit).toBeDefined();
+    // The wire `content` field must reflect the full long body, not
+    // the rationale. Pre-fix this was always the rationale.
+    expect(hit?.content).toBe(CONTENT_BODY);
+  });
+
+  it("falls back to rationale when content is omitted (defensive default)", async () => {
+    // Internal CLI workflows or scripted seeds may not supply
+    // `content`. The use case defaults to `rationale` so the
+    // persisted column stays non-empty and the FTS index keeps the
+    // entry searchable.
+    const result = await ctx.memory.recordDecision.record({
+      workspaceId: ctx.workspaceId,
+      sessionId: null,
+      title: "Internal seed without content",
+      rationale: "Backfill default kicks in",
+      // intentionally no `content` field — the use case must default
+      // to rationale so the persisted column stays non-empty.
+      tags: Tags.empty(),
+      scope: Scope.project(),
+    });
+
+    const row = ctx.database
+      .prepare("SELECT rationale, content FROM decisions WHERE id = ?")
+      .get(result.decisionId.toString()) as
+      | { readonly rationale: string; readonly content: string }
+      | undefined;
+    expect(row).toBeDefined();
+    expect(row?.rationale).toBe("Backfill default kicks in");
+    expect(row?.content).toBe("Backfill default kicks in");
+  });
+});

--- a/code/tests/integration/smoke.test.ts
+++ b/code/tests/integration/smoke.test.ts
@@ -31,7 +31,7 @@ describe("integration / smoke / container wiring", () => {
     expect(ctx.secrets.scanText).toBeDefined();
   });
 
-  it("applied every shipped migration (000-007)", () => {
+  it("applied every shipped migration (000-008)", () => {
     const stmt = ctx.database.prepare(
       "SELECT version FROM schema_migrations ORDER BY version ASC",
     );
@@ -44,7 +44,10 @@ describe("integration / smoke / container wiring", () => {
     // triggers to only fire when an FTS-mirrored column changes, so
     // the curator's `applyDecayBatch` UPDATEs do not pay a full FTS5
     // reindex per row.
-    expect(versions).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    // Migration 008 (B-MCP-4 / issue #3) adds the `decisions.content`
+    // column and rebuilds the FTS5 index over it so the wire `content`
+    // field stops being silently dropped on `mem.remember`.
+    expect(versions).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   it("registered the six MVP tools on the registry", () => {

--- a/code/tests/unit/memory/domain/value-objects.test.ts
+++ b/code/tests/unit/memory/domain/value-objects.test.ts
@@ -11,6 +11,7 @@ import { SessionId } from "../../../../src/modules/memory/domain/value-objects/s
 import { RelationId } from "../../../../src/modules/memory/domain/value-objects/relation-id.ts";
 import { DecisionTitle } from "../../../../src/modules/memory/domain/value-objects/decision-title.ts";
 import { Rationale } from "../../../../src/modules/memory/domain/value-objects/rationale.ts";
+import { DecisionContent } from "../../../../src/modules/memory/domain/value-objects/decision-content.ts";
 import { LearningText } from "../../../../src/modules/memory/domain/value-objects/learning-text.ts";
 import { LearningSeverity } from "../../../../src/modules/memory/domain/value-objects/learning-severity.ts";
 import { EntityName } from "../../../../src/modules/memory/domain/value-objects/entity-name.ts";
@@ -100,6 +101,34 @@ describe("Rationale", () => {
 
   it("rejects too-long (>5000 chars)", () => {
     expect(() => Rationale.from("x".repeat(5001))).toThrow(InvalidInputError);
+  });
+});
+
+describe("DecisionContent (B-MCP-4)", () => {
+  it("trims and accepts multi-line long-form text", () => {
+    expect(DecisionContent.from("paragraph 1\n\nparagraph 2").toString()).toBe(
+      "paragraph 1\n\nparagraph 2",
+    );
+  });
+
+  it("rejects empty", () => {
+    expect(() => DecisionContent.from("")).toThrow(InvalidInputError);
+  });
+
+  it("rejects whitespace-only", () => {
+    expect(() => DecisionContent.from("   \n\t")).toThrow(InvalidInputError);
+  });
+
+  it("accepts up to 50,000 chars (the cap is well above Rationale's 5,000)", () => {
+    expect(DecisionContent.from("x".repeat(50_000)).toString().length).toBe(
+      50_000,
+    );
+  });
+
+  it("rejects too-long (>50,000 chars)", () => {
+    expect(() => DecisionContent.from("x".repeat(50_001))).toThrow(
+      InvalidInputError,
+    );
   });
 });
 

--- a/code/tests/unit/memory/infrastructure/json-memory-exporter.test.ts
+++ b/code/tests/unit/memory/infrastructure/json-memory-exporter.test.ts
@@ -12,6 +12,7 @@ import { EntityId } from "../../../../src/modules/memory/domain/value-objects/en
 import { TaskId } from "../../../../src/modules/memory/domain/value-objects/task-id.ts";
 import { SessionId } from "../../../../src/modules/memory/domain/value-objects/session-id.ts";
 import { DecisionTitle } from "../../../../src/modules/memory/domain/value-objects/decision-title.ts";
+import { DecisionContent } from "../../../../src/modules/memory/domain/value-objects/decision-content.ts";
 import { Rationale } from "../../../../src/modules/memory/domain/value-objects/rationale.ts";
 import { LearningSeverity } from "../../../../src/modules/memory/domain/value-objects/learning-severity.ts";
 import { LearningText } from "../../../../src/modules/memory/domain/value-objects/learning-text.ts";
@@ -69,6 +70,7 @@ describe("JsonMemoryExporter.serialise", () => {
       sessionId: null,
       title: DecisionTitle.from("T"),
       rationale: Rationale.from("R"),
+      content: DecisionContent.from("Long-form content body"),
       tags: makeTags(["a"]),
       confidence: Confidence.full(),
       scope: Scope.module("auth"),

--- a/code/tests/unit/memory/infrastructure/json-memory-importer.test.ts
+++ b/code/tests/unit/memory/infrastructure/json-memory-importer.test.ts
@@ -7,6 +7,7 @@ import { Entity } from "../../../../src/modules/memory/domain/aggregates/entity.
 import { DecisionId } from "../../../../src/modules/memory/domain/value-objects/decision-id.ts";
 import { EntityId } from "../../../../src/modules/memory/domain/value-objects/entity-id.ts";
 import { DecisionTitle } from "../../../../src/modules/memory/domain/value-objects/decision-title.ts";
+import { DecisionContent } from "../../../../src/modules/memory/domain/value-objects/decision-content.ts";
 import { Rationale } from "../../../../src/modules/memory/domain/value-objects/rationale.ts";
 import { EntityName } from "../../../../src/modules/memory/domain/value-objects/entity-name.ts";
 import { EntityKind } from "../../../../src/modules/memory/domain/value-objects/entity-kind.ts";
@@ -86,6 +87,7 @@ describe("JsonMemoryImporter.parse", () => {
       sessionId: null,
       title: DecisionTitle.from("T"),
       rationale: Rationale.from("R"),
+      content: DecisionContent.from("Long-form body"),
       tags: makeTags(["a"]),
       confidence: Confidence.full(),
       scope: Scope.project(),
@@ -131,6 +133,7 @@ describe("JsonMemoryImporter.parse", () => {
       sessionId: null,
       title: DecisionTitle.from("T"),
       rationale: Rationale.from("R"),
+      content: DecisionContent.from("Long-form body"),
       tags: makeTags(),
       confidence: Confidence.full(),
       scope: Scope.project(),

--- a/code/tests/unit/memory/infrastructure/sqlite-decision-repository.test.ts
+++ b/code/tests/unit/memory/infrastructure/sqlite-decision-repository.test.ts
@@ -4,6 +4,7 @@ import { Decision } from "../../../../src/modules/memory/domain/aggregates/decis
 import { DecisionId } from "../../../../src/modules/memory/domain/value-objects/decision-id.ts";
 import { DecisionStatus } from "../../../../src/modules/memory/domain/value-objects/decision-status.ts";
 import { DecisionTitle } from "../../../../src/modules/memory/domain/value-objects/decision-title.ts";
+import { DecisionContent } from "../../../../src/modules/memory/domain/value-objects/decision-content.ts";
 import { Rationale } from "../../../../src/modules/memory/domain/value-objects/rationale.ts";
 import { Scope } from "../../../../src/modules/memory/domain/value-objects/scope.ts";
 import { EmbeddingStatus } from "../../../../src/modules/memory/domain/value-objects/embedding-status.ts";
@@ -51,6 +52,9 @@ function buildDecision(args: {
     sessionId: null,
     title: DecisionTitle.from(args.title ?? "Adopt SQLCipher"),
     rationale: Rationale.from("encryption at rest"),
+    content: DecisionContent.from(
+      "Encryption at rest using SQLCipher. Long-form body explaining the choice.",
+    ),
     tags: makeTags(["db"]),
     confidence: Confidence.full(),
     scope: args.scope ?? Scope.project(),
@@ -183,6 +187,7 @@ describe("SqliteDecisionRepository.findActiveByTags", () => {
       sessionId: null,
       title: DecisionTitle.from("T1"),
       rationale: Rationale.from("r"),
+      content: DecisionContent.from("Body 1"),
       tags: makeTags(["db", "perf"]),
       confidence: Confidence.full(),
       scope: Scope.project(),
@@ -196,6 +201,7 @@ describe("SqliteDecisionRepository.findActiveByTags", () => {
       sessionId: null,
       title: DecisionTitle.from("T2"),
       rationale: Rationale.from("r"),
+      content: DecisionContent.from("Body 2"),
       tags: makeTags(["sec"]),
       confidence: Confidence.full(),
       scope: Scope.project(),

--- a/code/tests/unit/memory/infrastructure/sqlite-memory-snapshot-reader.test.ts
+++ b/code/tests/unit/memory/infrastructure/sqlite-memory-snapshot-reader.test.ts
@@ -14,6 +14,7 @@ import { DecisionId } from "../../../../src/modules/memory/domain/value-objects/
 import { TaskId } from "../../../../src/modules/memory/domain/value-objects/task-id.ts";
 import { SessionId } from "../../../../src/modules/memory/domain/value-objects/session-id.ts";
 import { DecisionTitle } from "../../../../src/modules/memory/domain/value-objects/decision-title.ts";
+import { DecisionContent } from "../../../../src/modules/memory/domain/value-objects/decision-content.ts";
 import { Rationale } from "../../../../src/modules/memory/domain/value-objects/rationale.ts";
 import { TaskTitle } from "../../../../src/modules/memory/domain/value-objects/task-title.ts";
 import { TaskPriority } from "../../../../src/modules/memory/domain/value-objects/task-priority.ts";
@@ -111,6 +112,7 @@ describe("SqliteMemorySnapshotReader.read", () => {
       sessionId: null,
       title: DecisionTitle.from("D"),
       rationale: Rationale.from("R"),
+      content: DecisionContent.from("body"),
       tags: makeTags(),
       confidence: Confidence.full(),
       scope: Scope.project(),

--- a/code/tests/unit/memory/infrastructure/sqlite-memory-stats-reader.test.ts
+++ b/code/tests/unit/memory/infrastructure/sqlite-memory-stats-reader.test.ts
@@ -13,6 +13,7 @@ import { LearningId } from "../../../../src/modules/memory/domain/value-objects/
 import { EntityId } from "../../../../src/modules/memory/domain/value-objects/entity-id.ts";
 import { SessionId } from "../../../../src/modules/memory/domain/value-objects/session-id.ts";
 import { DecisionTitle } from "../../../../src/modules/memory/domain/value-objects/decision-title.ts";
+import { DecisionContent } from "../../../../src/modules/memory/domain/value-objects/decision-content.ts";
 import { Rationale } from "../../../../src/modules/memory/domain/value-objects/rationale.ts";
 import { LearningText } from "../../../../src/modules/memory/domain/value-objects/learning-text.ts";
 import { LearningSeverity } from "../../../../src/modules/memory/domain/value-objects/learning-severity.ts";
@@ -81,6 +82,7 @@ describe("SqliteMemoryStatsReader.read", () => {
       sessionId: null,
       title: DecisionTitle.from("d1"),
       rationale: Rationale.from("r"),
+      content: DecisionContent.from("body"),
       tags: makeTags(),
       confidence: Confidence.full(),
       scope: Scope.project(),
@@ -94,6 +96,7 @@ describe("SqliteMemoryStatsReader.read", () => {
       sessionId: null,
       title: DecisionTitle.from("d2"),
       rationale: Rationale.from("r"),
+      content: DecisionContent.from("body"),
       tags: makeTags(),
       confidence: Confidence.full(),
       scope: Scope.project(),

--- a/code/tests/unit/memory/infrastructure/sqlite-memory-wiper.test.ts
+++ b/code/tests/unit/memory/infrastructure/sqlite-memory-wiper.test.ts
@@ -7,6 +7,7 @@ import { Session } from "../../../../src/modules/memory/domain/aggregates/sessio
 import { DecisionId } from "../../../../src/modules/memory/domain/value-objects/decision-id.ts";
 import { SessionId } from "../../../../src/modules/memory/domain/value-objects/session-id.ts";
 import { DecisionTitle } from "../../../../src/modules/memory/domain/value-objects/decision-title.ts";
+import { DecisionContent } from "../../../../src/modules/memory/domain/value-objects/decision-content.ts";
 import { Rationale } from "../../../../src/modules/memory/domain/value-objects/rationale.ts";
 import { Scope } from "../../../../src/modules/memory/domain/value-objects/scope.ts";
 import { EmbeddingStatus } from "../../../../src/modules/memory/domain/value-objects/embedding-status.ts";
@@ -52,6 +53,7 @@ describe("SqliteMemoryWiper.wipe", () => {
       sessionId: null,
       title: DecisionTitle.from("D"),
       rationale: Rationale.from("R"),
+      content: DecisionContent.from("body"),
       tags: makeTags(),
       confidence: Confidence.full(),
       scope: Scope.project(),

--- a/code/tests/unit/retrieval/infrastructure/sqlite-memory-projection-repository.test.ts
+++ b/code/tests/unit/retrieval/infrastructure/sqlite-memory-projection-repository.test.ts
@@ -39,6 +39,7 @@ const SCHEMA = `
       id              TEXT    PRIMARY KEY,
       title           TEXT    NOT NULL,
       rationale       TEXT    NOT NULL,
+      content         TEXT    NOT NULL DEFAULT '',
       scope           TEXT    NOT NULL,
       module          TEXT,
       tags_json       TEXT    NOT NULL DEFAULT '[]',


### PR DESCRIPTION
## Que cambia

Cierra B-MCP-4 (issue #3, **critical, data loss**) via **Option B**
(decision tomada en el cuadro comparativo previo, alineada con la
regla durable "siempre priorizar la estabilidad"):

- **Migracion 008**: agrega columna `decisions.content TEXT NOT NULL
  DEFAULT ''`, backfill `content = rationale` para filas existentes,
  rebuild de `decisions_fts` virtual table incluyendo la nueva
  columna, triggers actualizados con UPDATE OF column-scope.
- **Domain**: nuevo VO `DecisionContent` (max 50K chars vs 5K de
  Rationale). Aggregate `Decision` lleva el campo en `record` y
  `rehydrate`.
- **Application**: `RecordDecision` port + use case aceptan content
  optional con fallback a rationale (defensa para flujos internos
  no-wire). Importer de handoff + JSON tambien.
- **Infrastructure**: `SqliteDecisionRepository` lee/escribe la
  columna; `SqliteMemoryProjectionRepository` (lado recall) la
  surface en el wire response. `JsonMemoryExporter` la incluye para
  round-trip lossless.
- **Composition**: `RememberFacadeAdapter` ya no descarta
  silenciosamente `input.content` para `kind=decision` — lo pasa
  intacto al use case.

## Por que

Fixes #3. Wire schema documentaba `content` como campo top-level
para todas las kinds desde v0.1.0; la tabla `decisions` no tenia la
columna; la facade descartaba el valor sin error. Recall retornaba
`rationale` en el campo wire `content` para empeorar la confusion.

Eleccion entre Option A (drop `content` del wire) y Option B
(agregar columna + migracion): **Option B** porque preservar el
contrato publico documentado tiene prioridad sobre la velocidad.

**Audit `turns`/`tasks`** confirmado: ambos tienen sus columnas
dedicadas (`summary`/`description`) que reciben `content` correctamente.
Solo `decisions` tenia el silent-drop. Sin scope creep.

## Tipo de cambio

- [x] fix — bug fix critical (data loss)
- [x] test — agrega tests
- [x] schema — migracion 008

## Checklist

- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` y `npm run lint:tests` EXIT=0
- [x] `npm run validate:modules` EXIT=0
- [x] `npm run build` EXIT=0
- [x] `npm run test` EXIT=0 — **2519 tests passing en 208 archivos** (was 2512 in 207)
- [x] Cero `any`, cero `as any`, cero `// @ts-ignore`
- [x] Tests nuevos cubren el cambio
- [x] Wire/protocolo MCP documentado en `docs/02 §4.4` (sin cambio — el contrato existente AHORA se honra)
- [ ] N/A — no introduce ADR (Option B es el cumplimiento del contrato, no un nuevo principio)
- [ ] HANDOFF.md se actualiza al cierre de v0.1.2-beta.3

## E2E que validan VALORES

- [x] Los tests asertan valores reales (no solo shape)

`tests/integration/N-decision-content-roundtrip.test.ts` (2 casos)
sigue la metodologia de Phase-9:

1. **Estado conocido**: workspace sin decisions.
2. **Insertar via wire**: `mem.remember(kind=decision)` con
   `rationale` SHORT y `content` LONG, distintos.
3. **SQL inspection**: `SELECT content FROM decisions WHERE id=?`
   debe contener el content largo, NO el rationale.
4. **Wire round-trip**: `mem.recall` con un token que aparece SOLO
   en content (no en title ni rationale) — debe traer el hit, y
   `result.content` debe ser el content largo (no el rationale,
   que era el comportamiento pre-fix).
5. **Defensive default**: insertar via use case interno sin
   `content` debe persistir `content = rationale`.

Pre-fix: `result.content === rationale` (siempre). Post-fix:
`result.content === content` (lo que el cliente envio).

## Notas para el reviewer

**Migracion 008 sobre datos existentes**:

- Backfill **`content = rationale`** (no empty string) para
  preservar searchability via FTS5 sobre la dogfood DB del usuario
  (27 decisions reales). Documentado en el SQL header.
- DROP TABLE + CREATE de `decisions_fts` necesario porque FTS5 no
  soporta ALTER. Operacion idempotente porque la migration runner
  honra `_meta`-based applied versions (la migracion no se reaplica).
- Los triggers se reescriben con `UPDATE OF title, rationale, content`
  para preservar la optimizacion de migration 007 (no reindexar FTS
  en updates de `confidence`).

**Forward-compat de exports legacy**:

- `JsonMemoryImporter.DecisionSchema` marca `content` como
  `optional` para consumir snapshots v0.1.0/v0.1.1 que no lo tienen.
  Cuando absent → buildDecision usa rationale.
- `SqliteMemoryProjectionRepository.DecisionRowSchema` igual:
  `content: z.string().optional()` con fallback a rationale en el
  preview.

**Por que NO se toca `turns` ni `tasks`**:

- Audit del facade routing:
  - turn: `summary: input.content` → tiene su columna `summary`.
  - task: `description: input.content` → tiene su columna `description`.
  - Ambos persisten correctamente. Solo `decisions` tenia el bug.