### PR TITLE
hotfix(docs): public-facing docs claimed bugs that were already closed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,11 @@ ADRs vigentes:
 ## Issues y bugs
 
 - Reportes en https://github.com/NetziTech/recall/issues
-- 4 issues abiertos hoy (B-MCP-2..5) — ver [`HANDOFF.md`](./HANDOFF.md) §6.14 + §8.
+- **0 issues abiertos** al cierre de Phase-11 (los 4 bugs B-MCP-2..5
+  detectados en el dogfood de Phase-9 quedaron cerrados en
+  `v0.1.2-beta.3` via PRs #17/#18/#19/#20). Ver
+  [`HANDOFF.md`](./HANDOFF.md) §6.16 +
+  [release notes](./docs/RELEASE-NOTES-v0.1.2-beta.3.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@
 [![ci](https://github.com/NetziTech/recall/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/NetziTech/recall/actions/workflows/ci.yml)
 [![sonarqube](https://img.shields.io/badge/sonarqube-quality_gate_passed-brightgreen)](https://sonar.netzi.dev/dashboard?id=recall)
 
-> **Estado del canal:** beta. La version `0.1.1` (canal `latest`) esta
-> deprecada por bugs descubiertos durante dogfood real. Trabajo activo en
-> `0.1.2-beta.x`. Ver [HANDOFF.md §6.14](./HANDOFF.md) y los
-> [4 issues abiertos](https://github.com/NetziTech/recall/issues).
+> **Estado del canal:** beta. `v0.1.2-beta.3` cierra **los 4 bugs**
+> descubiertos en el dogfood de Phase-9 (B-MCP-2/3/4/5 — semantic
+> recall, mem.health real state, decision content persistence,
+> mem.recall min_score). La version `0.1.1` (canal `latest`) sigue
+> deprecada hasta que `0.1.2` stable salga. Ver
+> [release notes](./docs/RELEASE-NOTES-v0.1.2-beta.3.md) +
+> [HANDOFF.md §6.16](./HANDOFF.md).
 
 ---
 
@@ -42,7 +45,8 @@ turns) en vez de "facts" planos.
 ## Quick start
 
 ```bash
-# Canal beta (recomendado mientras 0.1.2 sigue en desarrollo)
+# Canal beta (v0.1.2-beta.3 — los 4 bugs de Phase-9 cerrados; pendiente
+# de validacion via dogfood antes de promover a stable)
 npm install -g @netzi/recall@beta
 
 cd /tu/proyecto
@@ -131,8 +135,9 @@ Detalle: [docs/06-stack-tecnico.md](./docs/06-stack-tecnico.md).
 
 ## Issues / bugs / preguntas
 
-- [Issues abiertos](https://github.com/NetziTech/recall/issues) — actualmente
-  4 (B-MCP-2..5), todos descubiertos en dogfood real
+- [Issues abiertos](https://github.com/NetziTech/recall/issues) — **0**
+  al cierre de Phase-11 (los 4 bugs B-MCP-2..5 cerrados en
+  `v0.1.2-beta.3` via PRs #17/#18/#19/#20)
 - Reportar vulnerabilidades de seguridad: ver
   [SECURITY.md](./SECURITY.md)
 - Discusiones generales:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,13 +7,14 @@ Solo el canal `beta` recibe fixes activamente. `latest` (`0.1.1`) y
 
 | Version | Soportada | Razon |
 |---|---|---|
-| `0.1.2-beta.x` | si | canal activo en npm dist-tag `beta` |
-| `0.1.1` (latest) | no | deprecada por bugs B-MCP-2..5 (Phase-9) |
+| `0.1.2-beta.3` | si | canal activo en npm dist-tag `beta`; cierra los 4 bugs B-MCP-2..5 de Phase-9 |
+| `0.1.2-beta.0` | no | superseded por `0.1.2-beta.3` (mismo canal beta) |
+| `0.1.1` (latest) | no | deprecada por bugs B-MCP-2..5 (cerrados en `0.1.2-beta.3`); el dist-tag `latest` se actualiza cuando salga `0.1.2` stable |
 | `0.1.0` | no | deprecada por B-MCP-1 (Phase-8) |
 
-Roadmap de fixes y promote a `0.1.2` stable: ver
-[HANDOFF.md §6.14](./HANDOFF.md) y los
-[issues abiertos](https://github.com/NetziTech/recall/issues).
+Roadmap de fixes + promote a `0.1.2` stable: ver
+[HANDOFF.md §6.16](./HANDOFF.md) +
+[release notes](./docs/RELEASE-NOTES-v0.1.2-beta.3.md).
 
 ---
 

--- a/code/README.md
+++ b/code/README.md
@@ -28,9 +28,13 @@ Memory travels with the code: clone the repo, get the memory. Move the repo, the
 ## Install
 
 ```bash
-npm install -g @netzi/recall
-# or use it on demand
-npx @netzi/recall --help
+# Beta channel (recommended) — v0.1.2-beta.3 closes the four
+# Phase-9 dogfood defects (B-MCP-2/3/4/5). The `latest` dist-tag
+# is still pinned at v0.1.1 and is deprecated until v0.1.2 stable
+# lands; new installs should explicitly request `@beta`.
+npm install -g @netzi/recall@beta
+# or on demand:
+npx @netzi/recall@beta --help
 ```
 
 This installs two binaries:


### PR DESCRIPTION
## Que cambia

Hotfix que actualiza los docs publicos (README.md raiz, code/README.md
shipped en npm tarball, SECURITY.md, CONTRIBUTING.md) para reflejar
que los 4 bugs B-MCP-2..5 quedaron cerrados en \`v0.1.2-beta.3\`.

## Por que

PR #21 cerro el release v0.1.2-beta.3 pero solo actualizo:
- bumps de version (package.json, composition-root, sonar)
- HANDOFF.md (§0 + §6.16)
- docs/RELEASE-NOTES-v0.1.2-beta.3.md (nuevo)

**Olvidamos los public-facing docs**. Cuando el usuario tomo el
codigo a publish, el README.md root y el code/README.md (shipped en
npm tarball como package README) seguian diciendo:
- "trabajo activo en 0.1.2-beta.x"
- "4 issues abiertos hoy (B-MCP-2..5)"
- "npm install -g @netzi/recall" (defaults a latest=0.1.1 deprecada)

Sin este hotfix, la pagina del paquete en npmjs.com mostraria
informacion incorrecta sobre el estado del producto justo despues
del publish.

## Tipo de cambio

- [x] docs — solo documentacion publica
- [x] hotfix — fix sobre main (perdimos esto en el release; sin esto
      el npm publish sale con package.json correcto pero README
      stale)

## Updates

- **README.md** (root): banner refleja "v0.1.2-beta.3 cierra los 4
  bugs"; quick start nota canal beta; "Issues" reads "0 issues
  abiertos al cierre de Phase-11 (cerrados via PRs #17/#18/#19/#20)".
- **code/README.md** (shipped en npm tarball como package README):
  install command recomienda `@beta` con nota sobre por que; CTA
  apunta a beta.3 en vez de latest=0.1.1 deprecada.
- **SECURITY.md**: tabla de versiones soportadas incluye
  `0.1.2-beta.3` (active), marca `0.1.2-beta.0` como superseded,
  nota que latest=0.1.1 sigue deprecada hasta que 0.1.2 stable
  promote.
- **CONTRIBUTING.md**: "Issues y bugs" reads "0 issues abiertos al
  cierre de Phase-11" con pointers a §6.16 + release notes.

## Artefactos historicos intencionalmente sin tocar

- `docs/RELEASE-NOTES-v0.1.2-beta.0.md` — snapshot de un release
  anterior; release notes son inmutables por convencion.
- `CONTRIBUTING.md` line 139 commit-format example mencionando
  beta.0 — illustrative, no truth claim.

## Checklist

- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` y `npm run lint:tests` EXIT=0
- [x] `npm run validate:modules` EXIT=0
- [x] `npm run build` EXIT=0
- [x] `npm run test` EXIT=0 (no source files touched, suite previa sigue valida)
- [ ] N/A — wire/protocolo MCP no cambia
- [ ] N/A — no introduce ADR

## Plan post-merge

Per CONTRIBUTING.md hotfix flow: tras merge a main, hacer
merge-back a develop (PR separado). Adicionalmente, **actualizar el
tag v0.1.2-beta.3** para que apunte al commit con los doc fixes
incluidos antes del npm publish:

\`\`\`bash
git checkout main && git pull
git tag -d v0.1.2-beta.3
git push origin :refs/tags/v0.1.2-beta.3
git tag -a v0.1.2-beta.3 -m "v0.1.2-beta.3"
git push origin v0.1.2-beta.3
gh release edit v0.1.2-beta.3 --target main  # apunta el release al nuevo SHA
cd code && npm publish --tag beta --auth-type=web
\`\`\`

(El tag v0.1.2-beta.3 actualmente apunta a \`a826ef0\`, sin los
doc fixes. Re-tagging es seguro porque el GitHub release de
beta.3 aun no tiene downloads y npm publish todavia no se completo.)