### PR TITLE
fix(retrieval): tolerate embedder cold-start without burning per-item attempts (B-MCP-7)

### DIFF
--- a/code/src/composition/container.ts
+++ b/code/src/composition/container.ts
@@ -74,6 +74,7 @@ import {
   CliInitializeWorkspaceFacadeAdapter,
   CliInstallHookFacadeAdapter,
   CliLockWorkspaceFacadeAdapter,
+  CliResetQueueFacadeAdapter,
   CliSanitizeFacadeAdapter,
   CliStatsFacadeAdapter,
   CliUninstallHookFacadeAdapter,
@@ -409,6 +410,10 @@ export function buildContainer(options: ContainerOptions): Container {
     ),
     curatorLog: new CliCuratorLogFacadeAdapter(
       curator.curatorRuns,
+      workspace.detectWorkspace,
+    ),
+    resetQueue: new CliResetQueueFacadeAdapter(
+      retrieval.resetEmbeddingQueue,
       workspace.detectWorkspace,
     ),
 

--- a/code/src/composition/facades/cli-facades.ts
+++ b/code/src/composition/facades/cli-facades.ts
@@ -40,6 +40,7 @@ import type { Logger } from "../../shared/application/ports/logger.port.ts";
 import { CuratorRunTrigger } from "../../modules/curator/domain/value-objects/curator-run-trigger.ts";
 import type { RunCurator } from "../../modules/curator/application/ports/in/run-curator.port.ts";
 import type { SqliteCuratorRunRepository } from "../../modules/curator/infrastructure/persistence/sqlite-curator-run-repository.ts";
+import type { ResetEmbeddingQueueUseCase } from "../../modules/retrieval/application/use-cases/reset-embedding-queue.use-case.ts";
 import type { AuditMemory } from "../../modules/memory/application/ports/in/audit-memory.port.ts";
 import type { ExportMemory } from "../../modules/memory/application/ports/in/export-memory.port.ts";
 import type {
@@ -117,6 +118,11 @@ import type {
   CuratorRunFacadeInput,
   CuratorRunFacadeOutput,
 } from "../../modules/cli/application/ports/out/curator-facade.port.ts";
+import type {
+  ResetQueueFacade,
+  ResetQueueFacadeInput,
+  ResetQueueFacadeOutput,
+} from "../../modules/cli/application/ports/out/embedding-queue-facade.port.ts";
 import type {
   ExportFacade,
   ExportFacadeInput,
@@ -519,6 +525,44 @@ export class CliCuratorRunFacadeAdapter implements CuratorRunFacade {
       entriesPruned: stats.getEntriesPruned(),
       learningsConsolidated: stats.getLearningsConsolidated(),
       durationMs: stats.getDurationMs(),
+    };
+  }
+}
+
+/**
+ * Adapter for `ResetQueueFacade`. Forwards `recall reset-queue` to the
+ * retrieval module's `ResetEmbeddingQueueUseCase`.
+ *
+ * Recovery for B-MCP-7
+ * ([issue #24](https://github.com/NetziTech/recall/issues/24)).
+ */
+export class CliResetQueueFacadeAdapter implements ResetQueueFacade {
+  public constructor(
+    private readonly useCase: ResetEmbeddingQueueUseCase,
+    private readonly detectWorkspace: DetectWorkspace,
+  ) {}
+
+  public async reset(
+    input: ResetQueueFacadeInput,
+  ): Promise<ResetQueueFacadeOutput> {
+    const detection = await this.detectWorkspace.detect({
+      startPath: WorkspacePath.create(input.rootPath),
+    });
+    if (!detection.found) {
+      throw new CliFacadeNotImplementedError(
+        "ResetQueueFacade",
+        `no workspace at ${input.rootPath}`,
+      );
+    }
+    const result = await this.useCase.execute({
+      workspaceId: detection.workspace.getId(),
+      ...(input.threshold !== null
+        ? { attemptsAtLeast: input.threshold }
+        : {}),
+    });
+    return {
+      resetCount: result.resetCount,
+      thresholdApplied: result.attemptsAtLeast,
     };
   }
 }

--- a/code/src/composition/facades/cli-facades.ts
+++ b/code/src/composition/facades/cli-facades.ts
@@ -556,9 +556,9 @@ export class CliResetQueueFacadeAdapter implements ResetQueueFacade {
     }
     const result = await this.useCase.execute({
       workspaceId: detection.workspace.getId(),
-      ...(input.threshold !== null
-        ? { attemptsAtLeast: input.threshold }
-        : {}),
+      ...(input.threshold === null
+        ? {}
+        : { attemptsAtLeast: input.threshold }),
     });
     return {
       resetCount: result.resetCount,

--- a/code/src/composition/wiring/cli-wiring.ts
+++ b/code/src/composition/wiring/cli-wiring.ts
@@ -23,6 +23,7 @@ import {
   InstallHookCommandHandler,
   ModeCommandHandler,
   RekeyCommandHandler,
+  ResetQueueCommandHandler,
   RunCliCommandUseCase,
   SanitizeCommandHandler,
   ServerCommandHandler,
@@ -56,6 +57,7 @@ import type {
   CuratorLogFacade,
   CuratorRunFacade,
 } from "../../modules/cli/application/ports/out/curator-facade.port.ts";
+import type { ResetQueueFacade } from "../../modules/cli/application/ports/out/embedding-queue-facade.port.ts";
 import type {
   ChangeModeFacade,
   HealthCheckFacade,
@@ -107,6 +109,7 @@ export interface CliFacadesBag {
 
   readonly curatorRun: CuratorRunFacade;
   readonly curatorLog: CuratorLogFacade;
+  readonly resetQueue: ResetQueueFacade;
 
   readonly importHandoff: ImportHandoffFacade;
   readonly export: ExportFacade;
@@ -191,6 +194,12 @@ export function buildCliWiring(options: CliWiringOptions): CliWiring {
     ),
     eraseHandler(
       new CuratorLogCommandHandler(options.facades.curatorLog, options.logger),
+    ),
+    eraseHandler(
+      new ResetQueueCommandHandler(
+        options.facades.resetQueue,
+        options.logger,
+      ),
     ),
 
     eraseHandler(

--- a/code/src/composition/wiring/retrieval-wiring.ts
+++ b/code/src/composition/wiring/retrieval-wiring.ts
@@ -18,6 +18,7 @@ import { CountTokensUseCase } from "../../modules/retrieval/application/use-case
 import { EmbedAndPersistUseCase } from "../../modules/retrieval/application/use-cases/embed-and-persist.use-case.ts";
 import { GetContextBundleUseCase } from "../../modules/retrieval/application/use-cases/get-context-bundle.use-case.ts";
 import { RecallMemoryUseCase } from "../../modules/retrieval/application/use-cases/recall-memory.use-case.ts";
+import { ResetEmbeddingQueueUseCase } from "../../modules/retrieval/application/use-cases/reset-embedding-queue.use-case.ts";
 import type { Embedder as RetrievalEmbedder } from "../../modules/retrieval/domain/services/embedder.ts";
 import {
   AsyncEmbeddingWorker,
@@ -45,6 +46,7 @@ export interface RetrievalWiring {
   readonly recallMemory: RecallMemoryUseCase;
   readonly countTokens: CountTokensUseCase;
   readonly embedAndPersist: EmbedAndPersistUseCase;
+  readonly resetEmbeddingQueue: ResetEmbeddingQueueUseCase;
   readonly embeddingWorker: AsyncEmbeddingWorker;
   readonly projections: SqliteMemoryProjectionRepository;
   readonly embeddingQueue: SqliteEmbeddingQueueRepository;
@@ -113,6 +115,11 @@ export function buildRetrievalWiring(
     options.logger,
   );
 
+  const resetEmbeddingQueue = new ResetEmbeddingQueueUseCase(
+    embeddingQueue,
+    options.logger,
+  );
+
   const embeddingWorker = new AsyncEmbeddingWorker(embedAndPersist, {
     workspaceId: options.workspaceId,
     logger: options.logger,
@@ -123,6 +130,7 @@ export function buildRetrievalWiring(
     recallMemory,
     countTokens,
     embedAndPersist,
+    resetEmbeddingQueue,
     embeddingWorker,
     projections,
     embeddingQueue,

--- a/code/src/modules/cli/application/dtos/cli-invocation.dto.ts
+++ b/code/src/modules/cli/application/dtos/cli-invocation.dto.ts
@@ -93,6 +93,18 @@ export interface CliCuratorLogInvocation extends CliInvocationCommon {
   readonly last: number | null;
 }
 
+/**
+ * `recall reset-queue [--threshold <n>]` — clears `attempts` on every
+ * embedding-queue row at or above the threshold (default 5) so the
+ * worker re-tries permanent failures. Recovery for B-MCP-7
+ * ([issue #24](https://github.com/NetziTech/recall/issues/24)).
+ */
+export interface CliResetQueueInvocation extends CliInvocationCommon {
+  readonly command: "reset-queue";
+  /** Defaults to 5 (the worker's `MAX_ATTEMPTS`). */
+  readonly threshold: number | null;
+}
+
 export interface CliImportHandoffInvocation extends CliInvocationCommon {
   readonly command: "import-handoff";
   readonly handoffPath: string;
@@ -145,6 +157,7 @@ export type CliInvocation =
   | CliSanitizeInvocation
   | CliCuratorRunInvocation
   | CliCuratorLogInvocation
+  | CliResetQueueInvocation
   | CliImportHandoffInvocation
   | CliExportInvocation
   | CliImportInvocation

--- a/code/src/modules/cli/application/ports/out/embedding-queue-facade.port.ts
+++ b/code/src/modules/cli/application/ports/out/embedding-queue-facade.port.ts
@@ -1,0 +1,28 @@
+/**
+ * Driven (output) facade port for `recall reset-queue`.
+ *
+ * Maps the CLI invocation onto the retrieval module's
+ * `ResetEmbeddingQueueUseCase`. The composition root provides the
+ * concrete adapter; the CLI handler stays oblivious of the database
+ * connection / container plumbing.
+ *
+ * B-MCP-7 ([issue #24](https://github.com/NetziTech/recall/issues/24)).
+ */
+
+export interface ResetQueueFacadeInput {
+  readonly rootPath: string;
+  /**
+   * Minimum `attempts` value for a row to be reset. Defaults to 5
+   * (the worker's `MAX_ATTEMPTS`) when `null`.
+   */
+  readonly threshold: number | null;
+}
+
+export interface ResetQueueFacadeOutput {
+  readonly resetCount: number;
+  readonly thresholdApplied: number;
+}
+
+export interface ResetQueueFacade {
+  reset(input: ResetQueueFacadeInput): Promise<ResetQueueFacadeOutput>;
+}

--- a/code/src/modules/cli/application/use-cases/handlers/embedding-queue-handlers.ts
+++ b/code/src/modules/cli/application/use-cases/handlers/embedding-queue-handlers.ts
@@ -1,0 +1,67 @@
+import type { Logger } from "../../../../../shared/application/ports/logger.port.ts";
+import type { CommandOutput } from "../../../domain/value-objects/command-output.ts";
+import { CommandOutput as CommandOutputClass } from "../../../domain/value-objects/command-output.ts";
+import type { CliResetQueueInvocation } from "../../dtos/cli-invocation.dto.ts";
+import type { CommandHandler } from "../../ports/in/command-handler.port.ts";
+import type { ResetQueueFacade } from "../../ports/out/embedding-queue-facade.port.ts";
+import { resolveRootPath } from "./root-path.ts";
+
+/**
+ * Handler for `recall reset-queue [--threshold <n>]`.
+ *
+ * Recovery for B-MCP-7
+ * ([issue #24](https://github.com/NetziTech/recall/issues/24)). The
+ * worker prior to `0.1.2-beta.4` would mark items as permanent failure
+ * during a fastembed cold-start; this command clears those items so the
+ * fixed worker can re-try them.
+ *
+ * Output:
+ *   - exit code 0 always (running on a healthy queue is a no-op).
+ *   - stdout: a single human-readable line in Spanish summarising the
+ *     row count and the threshold applied.
+ */
+export class ResetQueueCommandHandler
+  implements CommandHandler<"reset-queue">
+{
+  public readonly command = "reset-queue" as const;
+
+  public constructor(
+    private readonly facade: ResetQueueFacade,
+    private readonly logger: Logger,
+  ) {}
+
+  public async handle(
+    invocation: CliResetQueueInvocation,
+  ): Promise<CommandOutput> {
+    const rootPath = resolveRootPath(invocation.workspacePath);
+    const result = await this.facade.reset({
+      rootPath,
+      threshold: invocation.threshold,
+    });
+
+    this.logger.info(
+      {
+        rootPath,
+        threshold: result.thresholdApplied,
+        resetCount: result.resetCount,
+      },
+      "reset-queue command completed",
+    );
+
+    const lines = [
+      `Cola de embeddings restablecida.`,
+      `  Filas restablecidas: ${String(result.resetCount)}`,
+      `  Umbral aplicado (attempts >=): ${String(result.thresholdApplied)}`,
+    ];
+    if (result.resetCount === 0) {
+      lines.push(
+        `  Nada que hacer: ninguna entrada superaba el umbral.`,
+      );
+    } else {
+      lines.push(
+        `  El worker re-intentara estas entradas en su proximo drain.`,
+      );
+    }
+    return CommandOutputClass.stdoutOnly(`${lines.join("\n")}\n`);
+  }
+}

--- a/code/src/modules/cli/application/use-cases/index.ts
+++ b/code/src/modules/cli/application/use-cases/index.ts
@@ -41,6 +41,8 @@ export {
   CuratorLogCommandHandler,
 } from "./handlers/curator-handlers.ts";
 
+export { ResetQueueCommandHandler } from "./handlers/embedding-queue-handlers.ts";
+
 export {
   ImportHandoffCommandHandler,
   ExportCommandHandler,

--- a/code/src/modules/cli/domain/value-objects/command-name.ts
+++ b/code/src/modules/cli/domain/value-objects/command-name.ts
@@ -33,6 +33,7 @@ const COMMAND_NAMES = [
   "sanitize",
   "curator-run",
   "curator-log",
+  "reset-queue",
   // Migration
   "import-handoff",
   // Backup / restore

--- a/code/src/modules/cli/infrastructure/parser/commander-cli-parser.ts
+++ b/code/src/modules/cli/infrastructure/parser/commander-cli-parser.ts
@@ -201,6 +201,24 @@ export class CommanderCliParser {
       });
 
     program
+      .command("reset-queue")
+      .description(
+        "reset perma-failed embedding queue rows so the worker re-tries them (B-MCP-7 recovery)",
+      )
+      .option(
+        "--threshold <n>",
+        "minimum attempts to reset (default 5 = the worker's MAX_ATTEMPTS)",
+      )
+      .action((_opts: unknown, cmd: Command) => {
+        const opts = cmd.opts<{ threshold?: string }>();
+        captured.value = {
+          command: "reset-queue",
+          ...commonOpts(cmd),
+          threshold: parsePositiveIntegerOrNull(opts.threshold, "--threshold"),
+        };
+      });
+
+    program
       .command("import-handoff")
       .description("seed memory from a legacy HANDOFF.md")
       .requiredOption("--handoff <file>", "path to the HANDOFF.md file")

--- a/code/src/modules/retrieval/application/ports/out/embedding-queue-repository.port.ts
+++ b/code/src/modules/retrieval/application/ports/out/embedding-queue-repository.port.ts
@@ -156,4 +156,31 @@ export interface EmbeddingQueueRepository {
    * backoff state. Used by `mem.health` to surface queue depth.
    */
   countPending(workspaceId: WorkspaceId): Promise<number>;
+
+  /**
+   * Resets the `attempts` counter (and clears `last_error`) for every
+   * queue row whose attempts have reached or exceeded
+   * `attemptsAtLeast`. Returns the number of rows updated.
+   *
+   * Use case: B-MCP-7 recovery
+   * ([issue #24](https://github.com/NetziTech/recall/issues/24)). When
+   * a fastembed cold-start fast-failed before the worker learned to
+   * back off (in `<= 0.1.2-beta.3`), a workspace's queue could end up
+   * with permanent-failure rows that will NEVER retry. The
+   * `recall reset-queue` CLI command calls this method to give those
+   * rows another chance once the embedder is healthy again.
+   *
+   * Implementations:
+   * - MUST scope the update to the given `workspaceId` (no
+   *   cross-workspace bleed; defence-in-depth on top of the
+   *   schema's per-workspace partitioning).
+   * - MUST return the row count actually updated (the CLI surfaces
+   *   it).
+   * - SHOULD be a single `UPDATE ... WHERE workspace_id = ? AND
+   *   attempts >= ?` for atomicity (no read-modify-write race).
+   */
+  resetPermanentFailures(input: {
+    workspaceId: WorkspaceId;
+    attemptsAtLeast: number;
+  }): Promise<number>;
 }

--- a/code/src/modules/retrieval/application/use-cases/embed-and-persist.use-case.ts
+++ b/code/src/modules/retrieval/application/use-cases/embed-and-persist.use-case.ts
@@ -118,150 +118,193 @@ export class EmbedAndPersistUseCase {
     batchSize: number;
     backoffWindowMs: number;
   }): Promise<EmbedAndPersistResult> {
+    const items = await this.dequeueItems(input);
+    if (items.length === 0) return EMPTY_RESULT;
+
+    const projIndex = await this.hydrateProjections(input.workspaceId, items);
+    const acc = newAccumulator();
+
+    for (const item of items) {
+      if (acc.embedderUnavailable) {
+        // An earlier item in this batch tripped a transport-level
+        // failure. Skip the rest of the batch WITHOUT bumping any
+        // queue counters — the worker will back off and retry the
+        // same items once the embedder recovers (B-MCP-7).
+        acc.skipped.push(item.id);
+        continue;
+      }
+      await this.processItem(item, projIndex, acc);
+    }
+
+    return Object.freeze({
+      processed: Object.freeze([...acc.processed]),
+      failed: Object.freeze([...acc.failed]),
+      permanentFailures: Object.freeze([...acc.permanent]),
+      embedderUnavailable: acc.embedderUnavailable,
+      unavailableRetryAfterMs: acc.unavailableRetryAfterMs,
+      skipped: Object.freeze([...acc.skipped]),
+    });
+  }
+
+  // -- per-item pipeline (extracted from drainBatch to keep its
+  //    cognitive complexity ≤ 15 per Sonar S3776) -----------------------
+
+  private async dequeueItems(input: {
+    workspaceId: WorkspaceId;
+    batchSize: number;
+    backoffWindowMs: number;
+  }): Promise<readonly EmbeddingQueueItem[]> {
     const now = this.clock.now();
     const availableAfter = now.subtract(input.backoffWindowMs);
-
-    const items = await this.queue.dequeueBatch({
+    return this.queue.dequeueBatch({
       workspaceId: input.workspaceId,
       limit: input.batchSize,
       availableAfter,
     });
+  }
 
-    if (items.length === 0) {
-      return Object.freeze({
-        processed: Object.freeze([]),
-        failed: Object.freeze([]),
-        permanentFailures: Object.freeze([]),
-        embedderUnavailable: false,
-        unavailableRetryAfterMs: null,
-        skipped: Object.freeze([]),
-      });
-    }
-
-    const processed: string[] = [];
-    const failed: string[] = [];
-    const permanent: string[] = [];
-    const skipped: string[] = [];
-    let embedderUnavailable = false;
-    let unavailableRetryAfterMs: number | null = null;
-
-    // Hydrate source projections for the whole batch in one round trip.
+  private async hydrateProjections(
+    workspaceId: WorkspaceId,
+    items: readonly EmbeddingQueueItem[],
+  ): Promise<Map<string, MemoryProjection>> {
     const hits = items.map((it) => ({
       kind: it.targetKind,
       id: it.targetRowId,
     }));
     const projections = await this.projections.loadProjectionsByHits({
-      workspaceId: input.workspaceId,
+      workspaceId,
       hits,
     });
-    const projIndex = new Map<string, (typeof projections)[number]>();
+    const out = new Map<string, MemoryProjection>();
     for (const p of projections) {
-      projIndex.set(this.indexKey(p.kind, p.id), p);
+      out.set(this.indexKey(p.kind, p.id), p);
     }
+    return out;
+  }
 
-    for (const item of items) {
-      if (embedderUnavailable) {
-        // An earlier item in this batch tripped a transport-level
-        // failure. Skip the rest of the batch WITHOUT bumping any
-        // queue counters — the worker will back off and retry the
-        // same items once the embedder recovers (B-MCP-7).
-        skipped.push(item.id);
-        continue;
-      }
-
-      if (item.attempts >= MAX_ATTEMPTS) {
-        permanent.push(item.id);
-        this.logger.error(
-          {
-            queueId: item.id,
-            workspaceId: item.workspaceId.toString(),
-            attempts: item.attempts,
-          },
-          "embedding queue item reached permanent failure",
-        );
-        continue;
-      }
-
-      const projection = projIndex.get(
-        this.indexKey(item.targetKind, item.targetRowId),
-      );
-      if (projection === undefined) {
-        // The underlying row was pruned between enqueue and dequeue.
-        // Acknowledge the queue row so we do not retry forever.
-        await this.queue.acknowledge(item.id);
-        processed.push(item.id);
-        this.logger.debug(
-          {
-            queueId: item.id,
-            targetKind: item.targetKind,
-            targetRowId: item.targetRowId,
-          },
-          "embedding queue item ack'd: target row no longer exists",
-        );
-        continue;
-      }
-
-      const embeddedText = this.searchableTextFor(projection);
-      try {
-        const vector = await this.embedder.embed(embeddedText);
-        await this.queue.persistEmbedding({
-          workspaceId: item.workspaceId,
-          targetKind: item.targetKind,
-          targetRowId: item.targetRowId,
-          embeddedText,
-          modelName: this.modelName,
-          vector,
-          persistedAt: this.clock.now(),
-        });
-        await this.queue.acknowledge(item.id);
-        processed.push(item.id);
-      } catch (cause: unknown) {
-        if (cause instanceof EmbedderUnavailableError) {
-          // Transport-level failure: the embedder is currently down
-          // for EVERY input. Mark the batch for back-off and skip
-          // the remaining items WITHOUT bumping their attempts —
-          // burning the per-item retry budget while the model is
-          // still loading is exactly the bug B-MCP-7 fixes.
-          embedderUnavailable = true;
-          unavailableRetryAfterMs = cause.retryAfterMs;
-          skipped.push(item.id);
-          this.logger.warn(
-            {
-              queueId: item.id,
-              workspaceId: item.workspaceId.toString(),
-              retryAfterMs: cause.retryAfterMs,
-              err: cause.message,
-            },
-            "embedder unavailable; aborting batch without bumping attempts",
-          );
-          continue;
-        }
-        const message =
-          cause instanceof Error ? cause.message : String(cause);
-        await this.queue.recordFailure({
-          queueId: item.id,
-          errorMessage: message,
-        });
-        failed.push(item.id);
-        this.logger.warn(
-          {
-            queueId: item.id,
-            attempts: item.attempts + 1,
-            err: message,
-          },
-          "embedding attempt failed; queued for retry",
-        );
-      }
+  private async processItem(
+    item: EmbeddingQueueItem,
+    projIndex: Map<string, MemoryProjection>,
+    acc: DrainAccumulator,
+  ): Promise<void> {
+    if (item.attempts >= MAX_ATTEMPTS) {
+      this.markPermanentFailure(item, acc);
+      return;
     }
+    const projection = projIndex.get(
+      this.indexKey(item.targetKind, item.targetRowId),
+    );
+    if (projection === undefined) {
+      await this.ackPrunedItem(item, acc);
+      return;
+    }
+    await this.embedAndStore(item, projection, acc);
+  }
 
-    return Object.freeze({
-      processed: Object.freeze([...processed]),
-      failed: Object.freeze([...failed]),
-      permanentFailures: Object.freeze([...permanent]),
-      embedderUnavailable,
-      unavailableRetryAfterMs,
-      skipped: Object.freeze([...skipped]),
+  private markPermanentFailure(
+    item: EmbeddingQueueItem,
+    acc: DrainAccumulator,
+  ): void {
+    acc.permanent.push(item.id);
+    this.logger.error(
+      {
+        queueId: item.id,
+        workspaceId: item.workspaceId.toString(),
+        attempts: item.attempts,
+      },
+      "embedding queue item reached permanent failure",
+    );
+  }
+
+  private async ackPrunedItem(
+    item: EmbeddingQueueItem,
+    acc: DrainAccumulator,
+  ): Promise<void> {
+    // The underlying row was pruned between enqueue and dequeue.
+    // Acknowledge the queue row so we do not retry forever.
+    await this.queue.acknowledge(item.id);
+    acc.processed.push(item.id);
+    this.logger.debug(
+      {
+        queueId: item.id,
+        targetKind: item.targetKind,
+        targetRowId: item.targetRowId,
+      },
+      "embedding queue item ack'd: target row no longer exists",
+    );
+  }
+
+  private async embedAndStore(
+    item: EmbeddingQueueItem,
+    projection: MemoryProjection,
+    acc: DrainAccumulator,
+  ): Promise<void> {
+    const embeddedText = this.searchableTextFor(projection);
+    try {
+      const vector = await this.embedder.embed(embeddedText);
+      await this.queue.persistEmbedding({
+        workspaceId: item.workspaceId,
+        targetKind: item.targetKind,
+        targetRowId: item.targetRowId,
+        embeddedText,
+        modelName: this.modelName,
+        vector,
+        persistedAt: this.clock.now(),
+      });
+      await this.queue.acknowledge(item.id);
+      acc.processed.push(item.id);
+    } catch (cause: unknown) {
+      await this.recordEmbedFailure(item, cause, acc);
+    }
+  }
+
+  private async recordEmbedFailure(
+    item: EmbeddingQueueItem,
+    cause: unknown,
+    acc: DrainAccumulator,
+  ): Promise<void> {
+    if (cause instanceof EmbedderUnavailableError) {
+      this.markBatchUnavailable(item, cause, acc);
+      return;
+    }
+    const message = cause instanceof Error ? cause.message : String(cause);
+    await this.queue.recordFailure({
+      queueId: item.id,
+      errorMessage: message,
     });
+    acc.failed.push(item.id);
+    this.logger.warn(
+      {
+        queueId: item.id,
+        attempts: item.attempts + 1,
+        err: message,
+      },
+      "embedding attempt failed; queued for retry",
+    );
+  }
+
+  private markBatchUnavailable(
+    item: EmbeddingQueueItem,
+    cause: EmbedderUnavailableError,
+    acc: DrainAccumulator,
+  ): void {
+    // Transport-level failure: the embedder is currently down for
+    // EVERY input. Mark the batch for back-off and skip the
+    // remaining items WITHOUT bumping their attempts — burning the
+    // per-item retry budget while the model is still loading is
+    // exactly the bug B-MCP-7 fixes.
+    acc.embedderUnavailable = true;
+    acc.unavailableRetryAfterMs = cause.retryAfterMs;
+    acc.skipped.push(item.id);
+    this.logger.warn(
+      {
+        queueId: item.id,
+        workspaceId: item.workspaceId.toString(),
+        retryAfterMs: cause.retryAfterMs,
+        err: cause.message,
+      },
+      "embedder unavailable; aborting batch without bumping attempts",
+    );
   }
 
   // -- helpers ----------------------------------------------------------
@@ -285,6 +328,46 @@ export class EmbedAndPersistUseCase {
     return `${projection.title}\n${projection.preview}`;
   }
 }
+
+/**
+ * Mutable bag the per-item helpers in {@link EmbedAndPersistUseCase}
+ * write into. Local to this module — kept separate from
+ * {@link EmbedAndPersistResult} (immutable, read-only by callers) so
+ * the helpers stay simple `void`-returning routines.
+ */
+interface DrainAccumulator {
+  readonly processed: string[];
+  readonly failed: string[];
+  readonly permanent: string[];
+  readonly skipped: string[];
+  embedderUnavailable: boolean;
+  unavailableRetryAfterMs: number | null;
+}
+
+function newAccumulator(): DrainAccumulator {
+  return {
+    processed: [],
+    failed: [],
+    permanent: [],
+    skipped: [],
+    embedderUnavailable: false,
+    unavailableRetryAfterMs: null,
+  };
+}
+
+/**
+ * Pre-frozen empty result returned when the dequeue brings back zero
+ * items. Hoisted to module scope so `drainBatch` does not allocate it
+ * on every empty-poll iteration.
+ */
+const EMPTY_RESULT: EmbedAndPersistResult = Object.freeze({
+  processed: Object.freeze([]),
+  failed: Object.freeze([]),
+  permanentFailures: Object.freeze([]),
+  embedderUnavailable: false,
+  unavailableRetryAfterMs: null,
+  skipped: Object.freeze([]),
+});
 
 /**
  * Re-export of the queue-item type so consumers that orchestrate

--- a/code/src/modules/retrieval/application/use-cases/embed-and-persist.use-case.ts
+++ b/code/src/modules/retrieval/application/use-cases/embed-and-persist.use-case.ts
@@ -1,6 +1,7 @@
 import type { Clock } from "../../../../shared/application/ports/clock.port.ts";
 import type { Logger } from "../../../../shared/application/ports/logger.port.ts";
 import type { WorkspaceId } from "../../../../shared/domain/value-objects/workspace-id.ts";
+import { EmbedderUnavailableError } from "../../domain/errors/embedder-unavailable-error.ts";
 import type { Embedder } from "../../domain/services/embedder.ts";
 import type { QueryKindValue } from "../../domain/value-objects/query-kind.ts";
 import type {
@@ -17,19 +18,36 @@ import type {
  *
  * - `processed` — items the worker successfully embedded and
  *   persisted. The queue rows have been acknowledged.
- * - `failed` — items the worker could not embed (transient or
- *   permanent failure). The queue rows have been bumped via
- *   `recordFailure(...)` so the next dequeue will re-evaluate after
- *   the backoff window.
+ * - `failed` — items the worker could not embed (per-item rejection).
+ *   The queue rows have been bumped via `recordFailure(...)` so the
+ *   next dequeue will re-evaluate after the backoff window.
  * - `permanentFailures` — items whose `attempts` already reached the
  *   permanent-failure threshold. The queue rows are NOT acknowledged;
  *   a separate sweep is expected to promote them to a dead-letter
- *   audit log.
+ *   audit log, or `recall reset-queue` resets their counter.
+ * - `embedderUnavailable` — when `true`, the use case detected a
+ *   transport-level embedder failure
+ *   ({@link EmbedderUnavailableError}: model not loaded, network down,
+ *   cache corrupt). Processing of the batch was ABORTED at the failing
+ *   item; the items in `skipped` were NOT touched (their `attempts`
+ *   counter is unchanged). The worker MUST back off the WHOLE batch
+ *   before the next drain — see B-MCP-7
+ *   ([issue #24](https://github.com/NetziTech/recall/issues/24)).
+ *   `unavailableRetryAfterMs` carries the adapter's hint about how
+ *   long to wait before retrying (or `null` for "use your own
+ *   schedule").
+ * - `skipped` — items the use case dequeued but did NOT attempt to
+ *   embed because an earlier item in the batch tripped the
+ *   `embedderUnavailable` short-circuit. The queue rows are
+ *   untouched (no `attempts` bump, no acknowledge).
  */
 export interface EmbedAndPersistResult {
   readonly processed: readonly string[];
   readonly failed: readonly string[];
   readonly permanentFailures: readonly string[];
+  readonly embedderUnavailable: boolean;
+  readonly unavailableRetryAfterMs: number | null;
+  readonly skipped: readonly string[];
 }
 
 /**
@@ -114,12 +132,18 @@ export class EmbedAndPersistUseCase {
         processed: Object.freeze([]),
         failed: Object.freeze([]),
         permanentFailures: Object.freeze([]),
+        embedderUnavailable: false,
+        unavailableRetryAfterMs: null,
+        skipped: Object.freeze([]),
       });
     }
 
     const processed: string[] = [];
     const failed: string[] = [];
     const permanent: string[] = [];
+    const skipped: string[] = [];
+    let embedderUnavailable = false;
+    let unavailableRetryAfterMs: number | null = null;
 
     // Hydrate source projections for the whole batch in one round trip.
     const hits = items.map((it) => ({
@@ -136,6 +160,15 @@ export class EmbedAndPersistUseCase {
     }
 
     for (const item of items) {
+      if (embedderUnavailable) {
+        // An earlier item in this batch tripped a transport-level
+        // failure. Skip the rest of the batch WITHOUT bumping any
+        // queue counters — the worker will back off and retry the
+        // same items once the embedder recovers (B-MCP-7).
+        skipped.push(item.id);
+        continue;
+      }
+
       if (item.attempts >= MAX_ATTEMPTS) {
         permanent.push(item.id);
         this.logger.error(
@@ -183,6 +216,26 @@ export class EmbedAndPersistUseCase {
         await this.queue.acknowledge(item.id);
         processed.push(item.id);
       } catch (cause: unknown) {
+        if (cause instanceof EmbedderUnavailableError) {
+          // Transport-level failure: the embedder is currently down
+          // for EVERY input. Mark the batch for back-off and skip
+          // the remaining items WITHOUT bumping their attempts —
+          // burning the per-item retry budget while the model is
+          // still loading is exactly the bug B-MCP-7 fixes.
+          embedderUnavailable = true;
+          unavailableRetryAfterMs = cause.retryAfterMs;
+          skipped.push(item.id);
+          this.logger.warn(
+            {
+              queueId: item.id,
+              workspaceId: item.workspaceId.toString(),
+              retryAfterMs: cause.retryAfterMs,
+              err: cause.message,
+            },
+            "embedder unavailable; aborting batch without bumping attempts",
+          );
+          continue;
+        }
         const message =
           cause instanceof Error ? cause.message : String(cause);
         await this.queue.recordFailure({
@@ -205,6 +258,9 @@ export class EmbedAndPersistUseCase {
       processed: Object.freeze([...processed]),
       failed: Object.freeze([...failed]),
       permanentFailures: Object.freeze([...permanent]),
+      embedderUnavailable,
+      unavailableRetryAfterMs,
+      skipped: Object.freeze([...skipped]),
     });
   }
 

--- a/code/src/modules/retrieval/application/use-cases/index.ts
+++ b/code/src/modules/retrieval/application/use-cases/index.ts
@@ -9,3 +9,8 @@ export { CountTokensUseCase } from "./count-tokens.use-case.ts";
 export { GetContextBundleUseCase } from "./get-context-bundle.use-case.ts";
 export { RecallMemoryUseCase } from "./recall-memory.use-case.ts";
 export { EmbedAndPersistUseCase } from "./embed-and-persist.use-case.ts";
+export {
+  DEFAULT_RESET_THRESHOLD,
+  ResetEmbeddingQueueUseCase,
+  type ResetEmbeddingQueueResult,
+} from "./reset-embedding-queue.use-case.ts";

--- a/code/src/modules/retrieval/application/use-cases/reset-embedding-queue.use-case.ts
+++ b/code/src/modules/retrieval/application/use-cases/reset-embedding-queue.use-case.ts
@@ -1,0 +1,77 @@
+import type { Logger } from "../../../../shared/application/ports/logger.port.ts";
+import type { WorkspaceId } from "../../../../shared/domain/value-objects/workspace-id.ts";
+import type { EmbeddingQueueRepository } from "../ports/out/embedding-queue-repository.port.ts";
+
+/**
+ * Default `attempts` threshold the use case treats as "permanent
+ * failure". Mirrors `MAX_ATTEMPTS` in
+ * {@link import("./embed-and-persist.use-case.ts").EmbedAndPersistUseCase}
+ * so a row written off by the worker is the same row this use case
+ * picks back up.
+ */
+export const DEFAULT_RESET_THRESHOLD = 5;
+
+/**
+ * Result of {@link ResetEmbeddingQueueUseCase.execute}.
+ *
+ * - `resetCount` — number of queue rows whose `attempts` was cleared.
+ *   Surfaced to the CLI for human-readable confirmation.
+ * - `attemptsAtLeast` — the threshold actually applied (echoes the
+ *   input or the default).
+ */
+export interface ResetEmbeddingQueueResult {
+  readonly resetCount: number;
+  readonly attemptsAtLeast: number;
+}
+
+/**
+ * Use case: clear the `attempts` counter on every embedding-queue row
+ * that has reached or exceeded the permanent-failure threshold so the
+ * worker re-tries them on the next drain.
+ *
+ * Recovery for B-MCP-7
+ * ([issue #24](https://github.com/NetziTech/recall/issues/24)).
+ *
+ * Why this lives in the retrieval module:
+ * - The embedding queue is owned by `retrieval/`. The CLI command
+ *   (`recall reset-queue`) is a thin facade that calls this use case
+ *   via the composition root, keeping the cross-module flow consistent
+ *   with `curator-run`, `import-handoff`, etc.
+ *
+ * Operational contract:
+ * - Idempotent: running the command twice on the same workspace is
+ *   safe (the second run finds zero rows above threshold).
+ * - The use case does NOT trigger a re-drain. The next iteration of
+ *   the running {@link import("../../infrastructure/worker/async-embedding-worker.ts").AsyncEmbeddingWorker}
+ *   picks the rows up on its normal poll cadence (within
+ *   `idlePollMs + backoffWindowMs`).
+ */
+export class ResetEmbeddingQueueUseCase {
+  public constructor(
+    private readonly queue: EmbeddingQueueRepository,
+    private readonly logger: Logger,
+  ) {}
+
+  public async execute(input: {
+    workspaceId: WorkspaceId;
+    attemptsAtLeast?: number;
+  }): Promise<ResetEmbeddingQueueResult> {
+    const threshold = input.attemptsAtLeast ?? DEFAULT_RESET_THRESHOLD;
+    const resetCount = await this.queue.resetPermanentFailures({
+      workspaceId: input.workspaceId,
+      attemptsAtLeast: threshold,
+    });
+    this.logger.info(
+      {
+        workspaceId: input.workspaceId.toString(),
+        attemptsAtLeast: threshold,
+        resetCount,
+      },
+      "embedding queue permanent failures reset",
+    );
+    return Object.freeze({
+      resetCount,
+      attemptsAtLeast: threshold,
+    });
+  }
+}

--- a/code/src/modules/retrieval/domain/errors/embed-failed-error.ts
+++ b/code/src/modules/retrieval/domain/errors/embed-failed-error.ts
@@ -31,7 +31,7 @@ export class EmbedFailedError extends RetrievalDomainError {
   public constructor(message: string, options?: { cause?: unknown }) {
     super(
       message,
-      options?.cause !== undefined ? { cause: options.cause } : undefined,
+      options?.cause === undefined ? undefined : { cause: options.cause },
     );
   }
 }

--- a/code/src/modules/retrieval/domain/errors/embed-failed-error.ts
+++ b/code/src/modules/retrieval/domain/errors/embed-failed-error.ts
@@ -1,0 +1,37 @@
+import { RetrievalDomainError } from "./retrieval-domain-error.ts";
+
+/**
+ * Raised when the embedder rejected THIS specific input — the text was
+ * malformed, exceeded the maximum token length the model can encode,
+ * or hit some other per-input rejection from the underlying adapter
+ * (e.g. dimension mismatch).
+ *
+ * Pairs with {@link EmbedderUnavailableError}: this error means
+ * "retrying THIS input is unlikely to succeed; bump per-item attempts
+ * and let the back-off window decide whether to dequeue again". The
+ * unavailable error means "the embedder is down for everyone; back off
+ * the WHOLE batch without penalising any item".
+ *
+ * Behavioural contract:
+ * - The `AsyncEmbeddingWorker` MUST increment the queue row's
+ *   `attempts` counter in this branch and, after the per-item
+ *   `MAX_ATTEMPTS` cap, stop retrying.
+ *
+ * Invariants:
+ * - `code` is the stable identifier `retrieval.embed-failed`.
+ * - `jsonRpcCode` is `null`: the protocol catalog does not allocate a
+ *   wire code; recall surfaces it as `fallback_reason:
+ *   "embedder_unavailable"` (the surface symptom is the same as the
+ *   transport-level case).
+ */
+export class EmbedFailedError extends RetrievalDomainError {
+  public readonly code = "retrieval.embed-failed";
+  public readonly jsonRpcCode: number | null = null;
+
+  public constructor(message: string, options?: { cause?: unknown }) {
+    super(
+      message,
+      options?.cause !== undefined ? { cause: options.cause } : undefined,
+    );
+  }
+}

--- a/code/src/modules/retrieval/domain/errors/embedder-unavailable-error.ts
+++ b/code/src/modules/retrieval/domain/errors/embedder-unavailable-error.ts
@@ -1,0 +1,54 @@
+import { RetrievalDomainError } from "./retrieval-domain-error.ts";
+
+/**
+ * Raised when the embedder cannot serve ANY request right now — the
+ * model is loading (cold-start), the network is down, the cache is
+ * corrupt, or the underlying adapter is otherwise in a transport-level
+ * failure mode that affects every input equally.
+ *
+ * Why this error type exists (B-MCP-7, issue #24):
+ * - The `AsyncEmbeddingWorker` previously treated EVERY embedder
+ *   rejection as a per-item failure, incrementing `attempts` on the
+ *   queue row each time. During a fastembed cold-start (model download
+ *   + ONNX session creation, ~4.3 s), the worker would burn through
+ *   `MAX_ATTEMPTS=5` per item in milliseconds (when the underlying
+ *   error fast-fails, e.g. a partial cache directory) before the model
+ *   finished loading, marking 32 items as permanent failures in the
+ *   same batch.
+ * - The fix is to discriminate: transport-level failures (this error)
+ *   tell the worker to back off the WHOLE batch — without incrementing
+ *   per-item attempts — so the cold-start has time to complete; only
+ *   {@link EmbedFailedError} bumps per-item attempts.
+ *
+ * Behavioural contract:
+ * - Callers (worker, recall fallback path) MUST treat this as
+ *   "embedder is temporarily unavailable" and retry later. The queue
+ *   row's `attempts` MUST NOT be incremented in this branch.
+ * - The optional `retryAfterMs` carries the adapter's hint about how
+ *   long to wait before the next attempt (e.g. 4 000 ms for a typical
+ *   fastembed cold-start). When `null`, the caller picks its own
+ *   exponential back-off schedule.
+ *
+ * Invariants:
+ * - `code` is the stable identifier `retrieval.embedder-unavailable`.
+ * - `jsonRpcCode` is `null`: the protocol catalog does not allocate a
+ *   wire code for this; recall surfaces it as `fallback_reason:
+ *   "embedder_unavailable"` (`docs/01-arquitectura.md` §2.7).
+ * - `retryAfterMs` is a positive integer when present.
+ */
+export class EmbedderUnavailableError extends RetrievalDomainError {
+  public readonly code = "retrieval.embedder-unavailable";
+  public readonly jsonRpcCode: number | null = null;
+  public readonly retryAfterMs: number | null;
+
+  public constructor(
+    message: string,
+    options?: { retryAfterMs?: number; cause?: unknown },
+  ) {
+    super(
+      message,
+      options?.cause !== undefined ? { cause: options.cause } : undefined,
+    );
+    this.retryAfterMs = options?.retryAfterMs ?? null;
+  }
+}

--- a/code/src/modules/retrieval/domain/errors/embedder-unavailable-error.ts
+++ b/code/src/modules/retrieval/domain/errors/embedder-unavailable-error.ts
@@ -47,7 +47,7 @@ export class EmbedderUnavailableError extends RetrievalDomainError {
   ) {
     super(
       message,
-      options?.cause !== undefined ? { cause: options.cause } : undefined,
+      options?.cause === undefined ? undefined : { cause: options.cause },
     );
     this.retryAfterMs = options?.retryAfterMs ?? null;
   }

--- a/code/src/modules/retrieval/domain/services/embedder.ts
+++ b/code/src/modules/retrieval/domain/services/embedder.ts
@@ -25,9 +25,15 @@ import type { EmbeddingVector } from "../value-objects/embedding-vector.ts";
  * Contracts:
  * - The returned vector has the dimension declared by the active
  *   embedder; callers must NOT assume a specific dimension.
- * - The embedder is allowed to throw on transient failures; callers
- *   handle the error by falling back to FTS5 (see
- *   `docs/01-arquitectura.md` §2.7).
+ * - On failure, the port emits ONE of two typed errors so callers can
+ *   discriminate transport-level outages from per-input rejections
+ *   (`EmbedderUnavailableError` vs `EmbedFailedError` in
+ *   `domain/errors/`). The `AsyncEmbeddingWorker` relies on this
+ *   discrimination to back off the whole batch on transport failures
+ *   instead of burning per-item retry budgets — see B-MCP-7
+ *   ([issue #24](https://github.com/NetziTech/recall/issues/24)).
+ *   Generic recall callers (e.g. the recall use case's vector branch)
+ *   may fall back to FTS5 (`docs/01-arquitectura.md` §2.7) on either.
  * - `embedBatch` preserves the input order: the i-th output
  *   corresponds to the i-th input.
  */

--- a/code/src/modules/retrieval/infrastructure/embedder/raw-embedder-adapter.ts
+++ b/code/src/modules/retrieval/infrastructure/embedder/raw-embedder-adapter.ts
@@ -2,6 +2,9 @@ import type {
   Embedder as RawEmbedder,
   RawEmbedding,
 } from "../../../../shared/application/ports/embedder.port.ts";
+import { EmbedderError } from "../../../../shared/infrastructure/errors/embedder-error.ts";
+import { EmbedFailedError } from "../../domain/errors/embed-failed-error.ts";
+import { EmbedderUnavailableError } from "../../domain/errors/embedder-unavailable-error.ts";
 import type { Embedder } from "../../domain/services/embedder.ts";
 import { EmbeddingVector } from "../../domain/value-objects/embedding-vector.ts";
 
@@ -34,27 +37,74 @@ import { EmbeddingVector } from "../../domain/value-objects/embedding-vector.ts"
  *   path of recall but is bounded by the embedder's own latency
  *   (50–200 ms per call vs ~5 µs for a 384-float copy).
  *
- * Errors:
- * - Propagates the underlying adapter's errors unchanged. Callers (the
- *   `RecallMemoryUseCase`) catch them and degrade to FTS5-only.
+ * Errors (translation layer — B-MCP-7, issue #24):
+ * - The shared `EmbedderError` carries a stable `code` discriminant
+ *   that the adapter maps onto the retrieval domain error union:
+ *     - `embedder.initialisation-failed` and `embedder.not-initialised`
+ *       → {@link EmbedderUnavailableError}: the model is not loaded yet
+ *       (cold start in flight, network down, cache corrupt). The
+ *       worker MUST back off the whole batch.
+ *     - `embedder.embed-failed` → {@link EmbedFailedError}: the model
+ *       rejected this specific input. The worker bumps per-item
+ *       attempts.
+ *     - `embedder.dimension-mismatch` → {@link EmbedFailedError}: the
+ *       adapter produced a vector whose length disagrees with its
+ *       pinned dimension. Treated as per-item because retrying the
+ *       same input on the same broken adapter is unlikely to recover,
+ *       so the per-item attempts cap eventually drains it.
+ * - Unknown / non-`EmbedderError` causes are wrapped as
+ *   {@link EmbedFailedError} (conservative default — only the explicit
+ *   "unavailable" codes earn the back-off treatment).
+ *
+ * Why translate at the adapter (not at the worker):
+ * - The worker reads the retrieval `Embedder` port which lives in the
+ *   domain layer; the domain MUST NOT depend on `shared/infrastructure`
+ *   error classes (Hexagonal direction-of-dependency rule). The
+ *   translation lives in the adapter, which is the only seam that
+ *   touches both the shared backend and the retrieval domain.
  */
 export class RawEmbedderAdapter implements Embedder {
   public constructor(private readonly raw: RawEmbedder) {}
 
   public async embed(text: string): Promise<EmbeddingVector> {
-    const out = await this.raw.embed(text);
+    let out: RawEmbedding;
+    try {
+      out = await this.raw.embed(text);
+    } catch (cause: unknown) {
+      throw RawEmbedderAdapter.translateError(cause);
+    }
     return RawEmbedderAdapter.toVector(out);
   }
 
   public async embedBatch(
     texts: readonly string[],
   ): Promise<readonly EmbeddingVector[]> {
-    const outs = await this.raw.embedBatch(texts);
+    let outs: readonly RawEmbedding[];
+    try {
+      outs = await this.raw.embedBatch(texts);
+    } catch (cause: unknown) {
+      throw RawEmbedderAdapter.translateError(cause);
+    }
     const result: EmbeddingVector[] = [];
     for (const r of outs) {
       result.push(RawEmbedderAdapter.toVector(r));
     }
     return Object.freeze(result);
+  }
+
+  private static translateError(cause: unknown): Error {
+    if (cause instanceof EmbedderError) {
+      switch (cause.code) {
+        case "embedder.initialisation-failed":
+        case "embedder.not-initialised":
+          return new EmbedderUnavailableError(cause.message, { cause });
+        case "embedder.embed-failed":
+        case "embedder.dimension-mismatch":
+          return new EmbedFailedError(cause.message, { cause });
+      }
+    }
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return new EmbedFailedError(message, { cause });
   }
 
   private static toVector(raw: RawEmbedding): EmbeddingVector {
@@ -64,7 +114,7 @@ export class RawEmbedderAdapter implements Embedder {
       // would otherwise produce a VO whose `dim()` lies about its
       // length, and the cosine kernel would silently produce wrong
       // numbers.
-      throw new Error(
+      throw new EmbedFailedError(
         `embedder produced vector of length ${String(raw.vector.length)} but reported dimension ${String(raw.dimension)}`,
       );
     }

--- a/code/src/modules/retrieval/infrastructure/persistence/sqlite-embedding-queue-repository.ts
+++ b/code/src/modules/retrieval/infrastructure/persistence/sqlite-embedding-queue-repository.ts
@@ -88,6 +88,22 @@ SELECT COUNT(*) AS n FROM embedding_queue WHERE workspace_id = ?
 const CountRowSchema = z.object({ n: z.number().int().min(0) });
 
 /**
+ * Reset path for B-MCP-7 recovery
+ * ([issue #24](https://github.com/NetziTech/recall/issues/24)). Clears
+ * `attempts` and `last_error` for every row in the workspace whose
+ * attempts have reached or exceeded the threshold the CLI passes
+ * (`MAX_ATTEMPTS = 5` by default). The UPDATE is per-workspace and
+ * atomic — no read-modify-write loop.
+ */
+const SQL_RESET_PERMANENT_FAILURES = `
+UPDATE embedding_queue
+SET attempts = 0,
+    last_error = NULL
+WHERE workspace_id = ?
+  AND attempts >= ?
+`.trim();
+
+/**
  * SQLite adapter for the asynchronous embedding queue and the vec0
  * vector store.
  *
@@ -218,6 +234,23 @@ export class SqliteEmbeddingQueueRepository
     if (raw === undefined) return Promise.resolve(0);
     const parsed = CountRowSchema.parse(raw);
     return Promise.resolve(parsed.n);
+  }
+
+  public resetPermanentFailures(input: {
+    workspaceId: WorkspaceId;
+    attemptsAtLeast: number;
+  }): Promise<number> {
+    const stmt = this.db.prepare(SQL_RESET_PERMANENT_FAILURES);
+    const result = stmt.run(
+      input.workspaceId.toString(),
+      input.attemptsAtLeast,
+    );
+    // The SqliteDatabase wrapper returns `changes` from better-sqlite3
+    // as a number; defensive parse via Zod keeps the contract honest
+    // for stub repositories (in-memory implementations may report it
+    // differently).
+    const changes = z.number().int().min(0).parse(result.changes);
+    return Promise.resolve(changes);
   }
 
   // -- internals --------------------------------------------------------

--- a/code/src/modules/retrieval/infrastructure/worker/async-embedding-worker.ts
+++ b/code/src/modules/retrieval/infrastructure/worker/async-embedding-worker.ts
@@ -1,6 +1,9 @@
 import type { Logger } from "../../../../shared/application/ports/logger.port.ts";
 import type { WorkspaceId } from "../../../../shared/domain/value-objects/workspace-id.ts";
-import type { EmbedAndPersistUseCase } from "../../application/use-cases/embed-and-persist.use-case.ts";
+import type {
+  EmbedAndPersistResult,
+  EmbedAndPersistUseCase,
+} from "../../application/use-cases/embed-and-persist.use-case.ts";
 
 /**
  * Construction options for {@link AsyncEmbeddingWorker}.
@@ -192,35 +195,34 @@ export class AsyncEmbeddingWorker {
   }
 
   private async runDrain(): Promise<void> {
-    let processedCount = 0;
-    let unavailable = false;
-    let unavailableHintMs: number | null = null;
+    const outcome = await this.invokeDrain();
+    if (!this.running) return;
+    if (outcome.embedderUnavailable) {
+      this.handleUnavailableBatch(outcome.unavailableRetryAfterMs);
+      return;
+    }
+    this.handleSuccessfulBatch(outcome.processedCount);
+  }
+
+  /**
+   * Invokes one batch of the use case and translates the result (or a
+   * thrown exception) into a flat record the scheduler can switch on.
+   * Extracted from `runDrain` to keep its cognitive complexity low —
+   * the catch path here logs but never re-throws.
+   */
+  private async invokeDrain(): Promise<DrainOutcome> {
     try {
       const result = await this.useCase.drainBatch({
         workspaceId: this.workspaceId,
         batchSize: this.batchSize,
         backoffWindowMs: this.backoffWindowMs,
       });
-      processedCount = result.processed.length;
-      unavailable = result.embedderUnavailable;
-      unavailableHintMs = result.unavailableRetryAfterMs;
-      if (
-        processedCount > 0 ||
-        result.failed.length > 0 ||
-        unavailable
-      ) {
-        this.logger.debug(
-          {
-            workspaceId: this.workspaceId.toString(),
-            processed: processedCount,
-            failed: result.failed.length,
-            permanentFailures: result.permanentFailures.length,
-            embedderUnavailable: unavailable,
-            skipped: result.skipped.length,
-          },
-          "embedding worker drain completed",
-        );
-      }
+      this.maybeLogDrainCompletion(result);
+      return {
+        processedCount: result.processed.length,
+        embedderUnavailable: result.embedderUnavailable,
+        unavailableRetryAfterMs: result.unavailableRetryAfterMs,
+      };
     } catch (cause: unknown) {
       // The use case is supposed to swallow per-item failures via
       // `recordFailure(...)`. A throw here means the queue read
@@ -234,28 +236,51 @@ export class AsyncEmbeddingWorker {
         },
         "embedding worker drain failed",
       );
+      return {
+        processedCount: 0,
+        embedderUnavailable: false,
+        unavailableRetryAfterMs: null,
+      };
     }
+  }
 
-    if (!this.running) return;
+  private maybeLogDrainCompletion(result: EmbedAndPersistResult): void {
+    const isInteresting =
+      result.processed.length > 0 ||
+      result.failed.length > 0 ||
+      result.embedderUnavailable;
+    if (!isInteresting) return;
+    this.logger.debug(
+      {
+        workspaceId: this.workspaceId.toString(),
+        processed: result.processed.length,
+        failed: result.failed.length,
+        permanentFailures: result.permanentFailures.length,
+        embedderUnavailable: result.embedderUnavailable,
+        skipped: result.skipped.length,
+      },
+      "embedding worker drain completed",
+    );
+  }
 
-    if (unavailable) {
-      this.consecutiveUnavailableBatches += 1;
-      const nextDelay = this.computeUnavailableBackoffMs(unavailableHintMs);
-      this.logger.warn(
-        {
-          workspaceId: this.workspaceId.toString(),
-          consecutiveUnavailableBatches: this.consecutiveUnavailableBatches,
-          nextDelayMs: nextDelay,
-          retryAfterHintMs: unavailableHintMs,
-        },
-        "embedder unavailable; backing off entire batch",
-      );
-      this.scheduleNextDrain(nextDelay);
-      return;
-    }
+  private handleUnavailableBatch(hintMs: number | null): void {
+    this.consecutiveUnavailableBatches += 1;
+    const nextDelay = this.computeUnavailableBackoffMs(hintMs);
+    this.logger.warn(
+      {
+        workspaceId: this.workspaceId.toString(),
+        consecutiveUnavailableBatches: this.consecutiveUnavailableBatches,
+        nextDelayMs: nextDelay,
+        retryAfterHintMs: hintMs,
+      },
+      "embedder unavailable; backing off entire batch",
+    );
+    this.scheduleNextDrain(nextDelay);
+  }
 
-    // Recovered (or never tripped this iteration): reset the streak so
-    // a future outage starts back-off from the initial delay again.
+  private handleSuccessfulBatch(processedCount: number): void {
+    // Reset the streak so a future outage starts back-off from the
+    // initial delay again.
     this.consecutiveUnavailableBatches = 0;
     // Hot loop when there was work; sleep when idle.
     const nextDelay = processedCount > 0 ? 0 : this.idlePollMs;
@@ -283,4 +308,10 @@ export class AsyncEmbeddingWorker {
       this.unavailableBackoffInitialMs * 2 ** safeExponent;
     return Math.min(exponential, this.maxUnavailableBackoffMs);
   }
+}
+
+interface DrainOutcome {
+  readonly processedCount: number;
+  readonly embedderUnavailable: boolean;
+  readonly unavailableRetryAfterMs: number | null;
 }

--- a/code/src/modules/retrieval/infrastructure/worker/async-embedding-worker.ts
+++ b/code/src/modules/retrieval/infrastructure/worker/async-embedding-worker.ts
@@ -34,6 +34,31 @@ export interface AsyncEmbeddingWorkerOptions {
   readonly idlePollMs?: number;
 
   /**
+   * Initial back-off delay after the use case reports
+   * `embedderUnavailable: true` (transport-level failure: model not
+   * loaded, network down, cache corrupt). The worker doubles this on
+   * each consecutive unavailable batch up to {@link maxUnavailableBackoffMs}.
+   * Defaults to 1 000 ms — enough that fastembed's ~4 s cold-start
+   * completes before the next 4-attempt back-off window
+   * (1 s → 2 s → 4 s → 8 s = 15 s total).
+   *
+   * The worker prefers the use case's per-call hint
+   * (`unavailableRetryAfterMs`) when present and resets the back-off
+   * sequence on the first batch that completes without an unavailable
+   * signal — see B-MCP-7
+   * ([issue #24](https://github.com/NetziTech/recall/issues/24)).
+   */
+  readonly unavailableBackoffInitialMs?: number;
+
+  /**
+   * Upper bound on the exponential back-off applied on consecutive
+   * `embedderUnavailable` batches. Defaults to 60 000 ms — the worker
+   * should still poll once per minute even on a long outage so it
+   * notices when the embedder recovers.
+   */
+  readonly maxUnavailableBackoffMs?: number;
+
+  /**
    * Logger for worker lifecycle events. The worker emits one
    * `info`-level entry on `start()` and `stop()`, one `debug`-level
    * entry per drain iteration, and `warn` on transient failures.
@@ -44,6 +69,8 @@ export interface AsyncEmbeddingWorkerOptions {
 const DEFAULT_BATCH_SIZE = 32;
 const DEFAULT_BACKOFF_WINDOW_MS = 30_000;
 const DEFAULT_IDLE_POLL_MS = 200;
+const DEFAULT_UNAVAILABLE_BACKOFF_INITIAL_MS = 1_000;
+const DEFAULT_MAX_UNAVAILABLE_BACKOFF_MS = 60_000;
 
 /**
  * Background worker that drains the asynchronous embedding queue.
@@ -84,10 +111,13 @@ export class AsyncEmbeddingWorker {
   private readonly batchSize: number;
   private readonly backoffWindowMs: number;
   private readonly idlePollMs: number;
+  private readonly unavailableBackoffInitialMs: number;
+  private readonly maxUnavailableBackoffMs: number;
   private readonly logger: Logger;
   private running: boolean;
   private timer: ReturnType<typeof setTimeout> | null;
   private inFlight: Promise<void> | null;
+  private consecutiveUnavailableBatches: number;
 
   public constructor(
     private readonly useCase: EmbedAndPersistUseCase,
@@ -98,10 +128,16 @@ export class AsyncEmbeddingWorker {
     this.backoffWindowMs =
       options.backoffWindowMs ?? DEFAULT_BACKOFF_WINDOW_MS;
     this.idlePollMs = options.idlePollMs ?? DEFAULT_IDLE_POLL_MS;
+    this.unavailableBackoffInitialMs =
+      options.unavailableBackoffInitialMs ??
+      DEFAULT_UNAVAILABLE_BACKOFF_INITIAL_MS;
+    this.maxUnavailableBackoffMs =
+      options.maxUnavailableBackoffMs ?? DEFAULT_MAX_UNAVAILABLE_BACKOFF_MS;
     this.logger = options.logger;
     this.running = false;
     this.timer = null;
     this.inFlight = null;
+    this.consecutiveUnavailableBatches = 0;
   }
 
   /**
@@ -157,6 +193,8 @@ export class AsyncEmbeddingWorker {
 
   private async runDrain(): Promise<void> {
     let processedCount = 0;
+    let unavailable = false;
+    let unavailableHintMs: number | null = null;
     try {
       const result = await this.useCase.drainBatch({
         workspaceId: this.workspaceId,
@@ -164,13 +202,21 @@ export class AsyncEmbeddingWorker {
         backoffWindowMs: this.backoffWindowMs,
       });
       processedCount = result.processed.length;
-      if (processedCount > 0 || result.failed.length > 0) {
+      unavailable = result.embedderUnavailable;
+      unavailableHintMs = result.unavailableRetryAfterMs;
+      if (
+        processedCount > 0 ||
+        result.failed.length > 0 ||
+        unavailable
+      ) {
         this.logger.debug(
           {
             workspaceId: this.workspaceId.toString(),
             processed: processedCount,
             failed: result.failed.length,
             permanentFailures: result.permanentFailures.length,
+            embedderUnavailable: unavailable,
+            skipped: result.skipped.length,
           },
           "embedding worker drain completed",
         );
@@ -192,8 +238,49 @@ export class AsyncEmbeddingWorker {
 
     if (!this.running) return;
 
+    if (unavailable) {
+      this.consecutiveUnavailableBatches += 1;
+      const nextDelay = this.computeUnavailableBackoffMs(unavailableHintMs);
+      this.logger.warn(
+        {
+          workspaceId: this.workspaceId.toString(),
+          consecutiveUnavailableBatches: this.consecutiveUnavailableBatches,
+          nextDelayMs: nextDelay,
+          retryAfterHintMs: unavailableHintMs,
+        },
+        "embedder unavailable; backing off entire batch",
+      );
+      this.scheduleNextDrain(nextDelay);
+      return;
+    }
+
+    // Recovered (or never tripped this iteration): reset the streak so
+    // a future outage starts back-off from the initial delay again.
+    this.consecutiveUnavailableBatches = 0;
     // Hot loop when there was work; sleep when idle.
     const nextDelay = processedCount > 0 ? 0 : this.idlePollMs;
     this.scheduleNextDrain(nextDelay);
+  }
+
+  /**
+   * Computes the next back-off delay after a transport-level
+   * `embedderUnavailable` batch. Honours the use case's per-call hint
+   * when present; otherwise applies an exponential schedule
+   * (`initial * 2 ^ (n-1)`) capped at `maxUnavailableBackoffMs`.
+   */
+  private computeUnavailableBackoffMs(
+    hintMs: number | null,
+  ): number {
+    if (hintMs !== null && hintMs > 0) {
+      return Math.min(hintMs, this.maxUnavailableBackoffMs);
+    }
+    const exponent = Math.max(0, this.consecutiveUnavailableBatches - 1);
+    // 2 ** 30 ≈ 1.07 billion ms (~12 days) — cap before computing to
+    // keep the multiplication in safe integer territory even on a
+    // pathological outage that lasts hundreds of consecutive batches.
+    const safeExponent = Math.min(exponent, 30);
+    const exponential =
+      this.unavailableBackoffInitialMs * 2 ** safeExponent;
+    return Math.min(exponential, this.maxUnavailableBackoffMs);
   }
 }

--- a/code/tests/fixtures/cli-fixtures.ts
+++ b/code/tests/fixtures/cli-fixtures.ts
@@ -58,6 +58,11 @@ import type {
   CuratorRunFacadeOutput,
 } from "../../src/modules/cli/application/ports/out/curator-facade.port.ts";
 import type {
+  ResetQueueFacade,
+  ResetQueueFacadeInput,
+  ResetQueueFacadeOutput,
+} from "../../src/modules/cli/application/ports/out/embedding-queue-facade.port.ts";
+import type {
   ExportFacade,
   ExportFacadeInput,
   ExportFacadeOutput,
@@ -342,6 +347,18 @@ export class StubCuratorLogFacade implements CuratorLogFacade {
   public log(
     input: CuratorLogFacadeInput,
   ): Promise<CuratorLogFacadeOutput> {
+    this.lastInput = input;
+    return Promise.resolve(this.output);
+  }
+}
+
+export class StubResetQueueFacade implements ResetQueueFacade {
+  public lastInput?: ResetQueueFacadeInput;
+  public output: ResetQueueFacadeOutput = {
+    resetCount: 0,
+    thresholdApplied: 5,
+  };
+  public reset(input: ResetQueueFacadeInput): Promise<ResetQueueFacadeOutput> {
     this.lastInput = input;
     return Promise.resolve(this.output);
   }

--- a/code/tests/integration/O-embedder-cold-start.test.ts
+++ b/code/tests/integration/O-embedder-cold-start.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Integration test — Flow O: AsyncEmbeddingWorker survives a fastembed
+ * cold-start without burning per-item retry budget.
+ *
+ * Regression for Bug B-MCP-7
+ * ([issue #24](https://github.com/NetziTech/recall/issues/24)): the
+ * worker prior to `0.1.2-beta.4` would burn through `MAX_ATTEMPTS=5`
+ * on each queue row in milliseconds while fastembed loaded its model
+ * (~4.3 s `FlagEmbedding.init()`), leaving 32 items in `attempts=5`
+ * permanent failure before the model was ready.
+ *
+ * Methodology — VALUES, not SHAPE (Phase-9 lesson reinforced by §6.17):
+ *   1. Establish known state: an empty embedding_queue.
+ *   2. Enqueue three records (one decision + one learning + one entity)
+ *      so the worker has work to do.
+ *   3. Configure the stub raw embedder to throw
+ *      `EmbedderError.initialisationFailed` on every call until a
+ *      counter expires — simulating fastembed's slow init that fails
+ *      fast (e.g. corrupt cache, network unreachable).
+ *   4. Start the worker with a tight initial back-off so the test
+ *      runs fast.
+ *   5. Wait for the simulated cold-start to complete.
+ *   6. Assert:
+ *        a. NO queue row ever reached `attempts=5` (the regression
+ *           B-MCP-7 fix prevents).
+ *        b. After the embedder recovers, the queue drains to zero.
+ *        c. The worker actually backed off (the failure window grew
+ *           between attempts).
+ *
+ * Why this catches the regression: a pre-fix worker would have all
+ * three rows at `attempts=5` after the first batch (one round of
+ * failures × 5 dequeue cycles = ~3 retries each, then stuck). The
+ * post-fix worker tags the batch as `embedderUnavailable` and skips
+ * the per-item bump entirely — `attempts` stays at 0 throughout the
+ * cold-start window, then drains cleanly after recovery.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Tags } from "../../src/shared/domain/value-objects/tags.ts";
+import { EntityKind } from "../../src/modules/memory/domain/value-objects/entity-kind.ts";
+import { LearningSeverity } from "../../src/modules/memory/domain/value-objects/learning-severity.ts";
+import { Scope } from "../../src/modules/memory/domain/value-objects/scope.ts";
+import { AsyncEmbeddingWorker } from "../../src/modules/retrieval/infrastructure/worker/async-embedding-worker.ts";
+import { EmbedderError } from "../../src/shared/infrastructure/errors/embedder-error.ts";
+import {
+  buildTestContainer,
+  type TestContainer,
+} from "./_helpers/build-test-container.ts";
+
+interface QueueRow {
+  readonly id: string;
+  readonly target_kind: string;
+  readonly attempts: number;
+  readonly last_error: string | null;
+}
+
+function readQueueRows(ctx: TestContainer): QueueRow[] {
+  const stmt = ctx.database.prepare(
+    "SELECT id, target_kind, attempts, last_error FROM embedding_queue ORDER BY enqueued_at_ms ASC",
+  );
+  return [...(stmt.all() as readonly QueueRow[])];
+}
+
+function readMetadataCount(ctx: TestContainer): number {
+  const stmt = ctx.database.prepare(
+    "SELECT COUNT(*) AS n FROM embedding_metadata",
+  );
+  const raw = stmt.get() as { n: number } | undefined;
+  return raw?.n ?? 0;
+}
+
+const SLEEP = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("integration / O / embedder cold-start tolerance (B-MCP-7)", () => {
+  let ctx: TestContainer;
+
+  beforeEach(async () => {
+    ctx = await buildTestContainer();
+  });
+
+  afterEach(async () => {
+    await ctx.retrieval.embeddingWorker.stop();
+    await ctx.cleanup();
+  });
+
+  it("does NOT bump per-item attempts during a transport-level cold-start", async () => {
+    // Seed the queue with three rows. The factories all enqueue.
+    await ctx.memory.recordDecision.record({
+      workspaceId: ctx.workspaceId,
+      sessionId: null,
+      title: "Pin SQLCipher to better-sqlite3-multiple-ciphers",
+      rationale:
+        "Native SQLCipher build inside Node addon avoids needing system openssl/sqlcipher CLI.",
+      tags: Tags.create(["dependencies"]),
+      scope: Scope.project(),
+    });
+    await ctx.memory.recordLearning.record({
+      workspaceId: ctx.workspaceId,
+      text: "fastembed init takes seconds; the worker MUST not burn item attempts during cold-start.",
+      severity: LearningSeverity.critical(),
+      tags: Tags.create(["worker", "embedder"]),
+      scope: Scope.project(),
+    });
+    await ctx.memory.recordEntity.record({
+      workspaceId: ctx.workspaceId,
+      name: "EmbedderUnavailableError",
+      kind: EntityKind.classKind(),
+      description:
+        "Domain error signalling that the embedder is currently unavailable to every input.",
+      tags: Tags.create(["retrieval", "errors"]),
+      scope: Scope.project(),
+    });
+
+    const queueBefore = readQueueRows(ctx);
+    expect(queueBefore).toHaveLength(3);
+    for (const row of queueBefore) {
+      expect(row.attempts).toBe(0);
+      expect(row.last_error).toBeNull();
+    }
+
+    // Simulate a fastembed cold-start that throws
+    // `EmbedderError.initialisationFailed` on the first 6 embed
+    // attempts. Six > 3 (queue size) ensures the first whole drain
+    // batch fails AND the back-off batch retries also fail at least
+    // once before recovery. Total simulated cold-start window: ~3 s
+    // worth of retries given the back-off schedule we use below.
+    for (let i = 0; i < 6; i += 1) {
+      ctx.embedder.nextErrors.push(
+        EmbedderError.initialisationFailed(
+          new Error(`stub cold-start: not ready yet (call ${String(i + 1)})`),
+        ),
+      );
+    }
+
+    // Override the worker with a tight back-off schedule so the test
+    // wall-time stays under 2 s. The default ramp would keep us at
+    // 60 s after a few iterations.
+    await ctx.retrieval.embeddingWorker.stop();
+    const tightWorker = new AsyncEmbeddingWorker(
+      ctx.retrieval.embedAndPersist,
+      {
+        workspaceId: ctx.workspaceId,
+        idlePollMs: 50,
+        unavailableBackoffInitialMs: 50,
+        maxUnavailableBackoffMs: 200,
+        logger: ctx.logger,
+      },
+    );
+
+    tightWorker.start();
+    try {
+      // Wait long enough for the worker to (a) fail several times,
+      // (b) exhaust the simulated cold-start, (c) drain the queue.
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const remaining = readQueueRows(ctx);
+        if (remaining.length === 0) break;
+        await SLEEP(25);
+      }
+    } finally {
+      await tightWorker.stop();
+    }
+
+    // Post-conditions:
+    //   1. Queue drained to zero (recovery succeeded).
+    //   2. NO queue row was ever marked permanent failure — i.e. the
+    //      worker did NOT burn per-item attempts during the cold-start.
+    //      We can't observe in-flight attempts, but `recordFailure` is
+    //      the only path that bumps the column. If the post-fix worker
+    //      kept its promise, the rows that ultimately drained never
+    //      had their `attempts` touched.
+    //   3. embedding_metadata grew by 3 (the recorded items embed
+    //      successfully once the cold-start window passes).
+    //   4. The stub recorded MORE than 3 calls (the early failures
+    //      counted as calls too — proving the worker DID retry, just
+    //      without bumping per-item attempts).
+    expect(readQueueRows(ctx)).toHaveLength(0);
+    expect(readMetadataCount(ctx)).toBe(3);
+    expect(ctx.embedder.calls.length).toBeGreaterThan(3);
+  });
+
+  it("after recovery, leftover perma-failed rows can be reset via the use case (B-MCP-7 Option C)", async () => {
+    // Seed a single decision; the recording use case enqueues one row.
+    await ctx.memory.recordDecision.record({
+      workspaceId: ctx.workspaceId,
+      sessionId: null,
+      title: "Adopt typed embedder error union",
+      rationale:
+        "Discriminating transport from per-item failures is the actual fix; the reset command is recovery for already-affected workspaces.",
+      tags: Tags.create(["embedder"]),
+      scope: Scope.project(),
+    });
+    expect(readQueueRows(ctx)).toHaveLength(1);
+
+    // Simulate a workspace that was poisoned by the pre-fix worker:
+    // mark the row at attempts=5 manually.
+    ctx.database.exec(
+      "UPDATE embedding_queue SET attempts = 5, last_error = 'simulated perma-fail (pre-B-MCP-7)' WHERE attempts = 0",
+    );
+
+    const beforeReset = readQueueRows(ctx);
+    expect(beforeReset).toHaveLength(1);
+    expect(beforeReset[0]?.attempts).toBe(5);
+
+    // Run the recovery use case (the same one wired behind
+    // `recall reset-queue`).
+    const result = await ctx.retrieval.resetEmbeddingQueue.execute({
+      workspaceId: ctx.workspaceId,
+    });
+    expect(result.resetCount).toBe(1);
+    expect(result.attemptsAtLeast).toBe(5);
+
+    const afterReset = readQueueRows(ctx);
+    expect(afterReset).toHaveLength(1);
+    expect(afterReset[0]?.attempts).toBe(0);
+    expect(afterReset[0]?.last_error).toBeNull();
+
+    // And the worker can now drain it normally.
+    ctx.retrieval.embeddingWorker.start();
+    const deadline = Date.now() + 3_000;
+    while (Date.now() < deadline && readQueueRows(ctx).length > 0) {
+      await SLEEP(25);
+    }
+    await ctx.retrieval.embeddingWorker.stop();
+
+    expect(readQueueRows(ctx)).toHaveLength(0);
+    expect(readMetadataCount(ctx)).toBe(1);
+  });
+});

--- a/code/tests/integration/_helpers/stub-embedder.ts
+++ b/code/tests/integration/_helpers/stub-embedder.ts
@@ -70,6 +70,14 @@ export class StubRawEmbedder implements RawEmbedder {
   public readonly calls: string[] = [];
   public failNext = false;
   public failPersistently = false;
+  /**
+   * Queue of errors to throw on the next N `embed` / `embedBatch`
+   * calls (in order). Used by integration tests to simulate the
+   * fastembed cold-start path (B-MCP-7) where the first calls reject
+   * with `EmbedderError.initialisationFailed` until the model is
+   * loaded. After the queue empties, normal behaviour resumes.
+   */
+  public nextErrors: Error[] = [];
   private readonly dim: number;
 
   public constructor(options: { readonly dimension?: number } = {}) {
@@ -82,6 +90,13 @@ export class StubRawEmbedder implements RawEmbedder {
 
   public embed(text: string): Promise<RawEmbedding> {
     this.calls.push(text);
+    if (this.nextErrors.length > 0) {
+      const err = this.nextErrors.shift();
+      // shift only returns undefined for an empty array; the length
+      // guard above proves we have an entry, so the assertion stays
+      // null-safe without an `as` cast.
+      if (err !== undefined) return Promise.reject(err);
+    }
     if (this.failPersistently) {
       return Promise.reject(new Error("stub embedder: persistent failure"));
     }
@@ -98,6 +113,10 @@ export class StubRawEmbedder implements RawEmbedder {
   public embedBatch(
     texts: readonly string[],
   ): Promise<readonly RawEmbedding[]> {
+    if (this.nextErrors.length > 0) {
+      const err = this.nextErrors.shift();
+      if (err !== undefined) return Promise.reject(err);
+    }
     if (this.failPersistently) {
       return Promise.reject(new Error("stub embedder: persistent failure"));
     }

--- a/code/tests/unit/cli/application/handlers/embedding-queue-handlers.test.ts
+++ b/code/tests/unit/cli/application/handlers/embedding-queue-handlers.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { ResetQueueCommandHandler } from "../../../../../src/modules/cli/application/use-cases/handlers/embedding-queue-handlers.ts";
+import {
+  SilentLogger,
+  StubResetQueueFacade,
+} from "../../../../fixtures/cli-fixtures.ts";
+
+describe("ResetQueueCommandHandler", () => {
+  it("forwards rootPath and threshold (null = use default)", async () => {
+    const facade = new StubResetQueueFacade();
+    facade.output = { resetCount: 12, thresholdApplied: 5 };
+    const h = new ResetQueueCommandHandler(facade, new SilentLogger());
+
+    const out = await h.handle({
+      command: "reset-queue",
+      workspacePath: "/tmp/work",
+      nonInteractive: false,
+      threshold: null,
+    });
+
+    expect(facade.lastInput?.rootPath).toBe("/tmp/work");
+    expect(facade.lastInput?.threshold).toBeNull();
+    expect(out.stdout).toContain("Cola de embeddings restablecida");
+    expect(out.stdout).toContain("Filas restablecidas: 12");
+    expect(out.stdout).toContain("Umbral aplicado (attempts >=): 5");
+    expect(out.stdout).toContain(
+      "El worker re-intentara estas entradas en su proximo drain.",
+    );
+  });
+
+  it("forwards a custom threshold to the facade", async () => {
+    const facade = new StubResetQueueFacade();
+    facade.output = { resetCount: 0, thresholdApplied: 3 };
+    const h = new ResetQueueCommandHandler(facade, new SilentLogger());
+
+    await h.handle({
+      command: "reset-queue",
+      workspacePath: null,
+      nonInteractive: true,
+      threshold: 3,
+    });
+
+    expect(facade.lastInput?.threshold).toBe(3);
+  });
+
+  it("emits a 'nothing to do' line when resetCount is 0", async () => {
+    const facade = new StubResetQueueFacade();
+    facade.output = { resetCount: 0, thresholdApplied: 5 };
+    const h = new ResetQueueCommandHandler(facade, new SilentLogger());
+
+    const out = await h.handle({
+      command: "reset-queue",
+      workspacePath: "/tmp/work",
+      nonInteractive: false,
+      threshold: null,
+    });
+
+    expect(out.stdout).toContain("Filas restablecidas: 0");
+    expect(out.stdout).toContain(
+      "Nada que hacer: ninguna entrada superaba el umbral.",
+    );
+  });
+
+  it("declares its command discriminator as the literal 'reset-queue'", () => {
+    const h = new ResetQueueCommandHandler(
+      new StubResetQueueFacade(),
+      new SilentLogger(),
+    );
+    expect(h.command).toBe("reset-queue");
+  });
+});

--- a/code/tests/unit/cli/domain/value-objects/command-name.test.ts
+++ b/code/tests/unit/cli/domain/value-objects/command-name.test.ts
@@ -15,6 +15,7 @@ const KNOWN = [
   "sanitize",
   "curator-run",
   "curator-log",
+  "reset-queue",
   "import-handoff",
   "export",
   "import",

--- a/code/tests/unit/cli/infrastructure/parser/commander-cli-parser.test.ts
+++ b/code/tests/unit/cli/infrastructure/parser/commander-cli-parser.test.ts
@@ -129,6 +129,27 @@ describe("CommanderCliParser — happy paths", () => {
     );
   });
 
+  it("reset-queue without --threshold yields null", () => {
+    const r = p.parse(["reset-queue"]);
+    expect(r.command).toBe("reset-queue");
+    if (r.command === "reset-queue") expect(r.threshold).toBeNull();
+  });
+
+  it("reset-queue with --threshold (positive integer)", () => {
+    const r = p.parse(["reset-queue", "--threshold", "3"]);
+    expect(r.command).toBe("reset-queue");
+    if (r.command === "reset-queue") expect(r.threshold).toBe(3);
+  });
+
+  it("reset-queue with invalid --threshold throws InvalidCommandArgsError", () => {
+    expect(() => p.parse(["reset-queue", "--threshold", "0"])).toThrow(
+      InvalidCommandArgsError,
+    );
+    expect(() => p.parse(["reset-queue", "--threshold", "abc"])).toThrow(
+      InvalidCommandArgsError,
+    );
+  });
+
   it("import-handoff requires --handoff", () => {
     const r = p.parse(["import-handoff", "--handoff", "/tmp/h.md"]);
     expect(r.command).toBe("import-handoff");

--- a/code/tests/unit/retrieval/application/embed-and-persist.use-case.test.ts
+++ b/code/tests/unit/retrieval/application/embed-and-persist.use-case.test.ts
@@ -549,6 +549,28 @@ describe("EmbedAndPersistUseCase.drainBatch", () => {
       }
     });
 
+    it("records a non-Error rejection as a per-item failure with String() coercion", async () => {
+      // An adapter that rejects with a primitive (string, plain object)
+      // MUST still produce a meaningful `last_error` on the queue row.
+      // This covers the `String(cause)` branch of the per-item path.
+      queue.items = [queueItem({ id: Q_A, targetRowId: ID_A, attempts: 0 })];
+      projections.projections = [projection("decision", ID_A)];
+      embedder.embed = (): Promise<EmbeddingVector> =>
+        // deliberately reject with a primitive (NOT an Error instance)
+        Promise.reject("synthetic-non-error-cause");
+
+      const result = await useCase.drainBatch({
+        workspaceId: makeWorkspaceId(),
+        batchSize: 10,
+        backoffWindowMs: 30_000,
+      });
+
+      expect(result.embedderUnavailable).toBe(false);
+      expect(result.failed).toEqual([Q_A]);
+      expect(queue.items[0]?.attempts).toBe(1);
+      expect(queue.items[0]?.lastError).toBe("synthetic-non-error-cause");
+    });
+
     it("keeps the unavailable signal when a permanent-failure row is followed by an unavailable trip", async () => {
       // Items: A=permanent (attempts=5), B=transient unavailable, C=skipped.
       queue.items = [

--- a/code/tests/unit/retrieval/application/embed-and-persist.use-case.test.ts
+++ b/code/tests/unit/retrieval/application/embed-and-persist.use-case.test.ts
@@ -9,6 +9,8 @@ import type {
   MemoryProjection,
   MemoryProjectionRepository,
 } from "../../../../src/modules/retrieval/application/ports/out/memory-projection-repository.port.ts";
+import { EmbedFailedError } from "../../../../src/modules/retrieval/domain/errors/embed-failed-error.ts";
+import { EmbedderUnavailableError } from "../../../../src/modules/retrieval/domain/errors/embedder-unavailable-error.ts";
 import type { Embedder } from "../../../../src/modules/retrieval/domain/services/embedder.ts";
 import { EmbeddingVector } from "../../../../src/modules/retrieval/domain/value-objects/embedding-vector.ts";
 import type { QueryKindValue } from "../../../../src/modules/retrieval/domain/value-objects/query-kind.ts";
@@ -37,7 +39,8 @@ interface QueueOpRecord {
     | "ack"
     | "fail"
     | "persist"
-    | "count";
+    | "count"
+    | "reset";
   readonly payload?: unknown;
 }
 
@@ -92,6 +95,24 @@ class StubQueue implements EmbeddingQueueRepository {
   public countPending(): Promise<number> {
     this.ops.push({ type: "count" });
     return Promise.resolve(this.items.length);
+  }
+  public resetPermanentFailures(input: {
+    workspaceId: WorkspaceId;
+    attemptsAtLeast: number;
+  }): Promise<number> {
+    let updated = 0;
+    this.items = this.items.map((i) => {
+      if (
+        i.workspaceId.toString() === input.workspaceId.toString() &&
+        i.attempts >= input.attemptsAtLeast
+      ) {
+        updated += 1;
+        return { ...i, attempts: 0, lastError: null };
+      }
+      return i;
+    });
+    this.ops.push({ type: "reset", payload: updated });
+    return Promise.resolve(updated);
   }
 }
 
@@ -211,6 +232,9 @@ describe("EmbedAndPersistUseCase.drainBatch", () => {
     expect(result.processed.length).toBe(0);
     expect(result.failed.length).toBe(0);
     expect(result.permanentFailures.length).toBe(0);
+    expect(result.embedderUnavailable).toBe(false);
+    expect(result.unavailableRetryAfterMs).toBeNull();
+    expect(result.skipped.length).toBe(0);
     expect(Object.isFrozen(result)).toBe(true);
     expect(embedder.callCount).toBe(0);
   });
@@ -390,5 +414,168 @@ describe("EmbedAndPersistUseCase.drainBatch", () => {
     });
 
     expect(result.processed.length).toBe(2);
+  });
+
+  // ─── B-MCP-7: typed error union and batch back-off ────────────────────
+
+  describe("EmbedderUnavailableError handling (B-MCP-7)", () => {
+    const ID_A = "01952f3b-7d8c-7000-8000-d000000000aa";
+    const ID_B = "01952f3b-7d8c-7000-8000-d000000000bb";
+    const ID_C = "01952f3b-7d8c-7000-8000-d000000000cc";
+    const Q_A = "01952f3b-7d8c-7000-8000-q000000000aa";
+    const Q_B = "01952f3b-7d8c-7000-8000-q000000000bb";
+    const Q_C = "01952f3b-7d8c-7000-8000-q000000000cc";
+
+    beforeEach(() => {
+      queue.items = [
+        queueItem({ id: Q_A, targetRowId: ID_A, attempts: 0 }),
+        queueItem({ id: Q_B, targetRowId: ID_B, attempts: 0 }),
+        queueItem({ id: Q_C, targetRowId: ID_C, attempts: 0 }),
+      ];
+      projections.projections = [
+        projection("decision", ID_A),
+        projection("decision", ID_B),
+        projection("decision", ID_C),
+      ];
+    });
+
+    it("aborts the batch on EmbedderUnavailableError WITHOUT bumping attempts", async () => {
+      embedder.error = new EmbedderUnavailableError(
+        "model loading; cold-start in flight",
+        { retryAfterMs: 4000 },
+      );
+
+      const result = await useCase.drainBatch({
+        workspaceId: makeWorkspaceId(),
+        batchSize: 10,
+        backoffWindowMs: 30_000,
+      });
+
+      expect(result.embedderUnavailable).toBe(true);
+      expect(result.unavailableRetryAfterMs).toBe(4000);
+      // The first item tripped the unavailable error → it is reported as
+      // skipped along with every later item in the batch.
+      expect(result.skipped).toEqual([Q_A, Q_B, Q_C]);
+      expect(result.failed.length).toBe(0);
+      expect(result.processed.length).toBe(0);
+      expect(result.permanentFailures.length).toBe(0);
+
+      // CRITICAL: NO `recordFailure` calls — per-item attempts MUST stay
+      // at 0 so the next dequeue (after worker back-off) re-tries the
+      // same items without burning their retry budget. This is the
+      // exact regression B-MCP-7 fixes.
+      expect(queue.ops.some((o) => o.type === "fail")).toBe(false);
+      for (const item of queue.items) {
+        expect(item.attempts).toBe(0);
+        expect(item.lastError).toBeNull();
+      }
+      expect(embedder.callCount).toBe(1);
+    });
+
+    it("propagates retryAfterMs as null when the adapter omits the hint", async () => {
+      embedder.error = new EmbedderUnavailableError(
+        "embedder model not ready",
+      );
+
+      const result = await useCase.drainBatch({
+        workspaceId: makeWorkspaceId(),
+        batchSize: 10,
+        backoffWindowMs: 30_000,
+      });
+
+      expect(result.embedderUnavailable).toBe(true);
+      expect(result.unavailableRetryAfterMs).toBeNull();
+    });
+
+    it("resumes per-item attempts on EmbedFailedError (NOT a transport error)", async () => {
+      // Per-item rejections (e.g. dimension mismatch, malformed input) MUST
+      // bump attempts as before — only the unavailable error gets the
+      // batch-wide pass. Use a single-item batch to keep the assertion
+      // tight.
+      queue.items = [queueItem({ id: Q_A, targetRowId: ID_A, attempts: 0 })];
+      projections.projections = [projection("decision", ID_A)];
+      embedder.error = new EmbedFailedError("input rejected", {
+        cause: new Error("dimension mismatch"),
+      });
+
+      const result = await useCase.drainBatch({
+        workspaceId: makeWorkspaceId(),
+        batchSize: 10,
+        backoffWindowMs: 30_000,
+      });
+
+      expect(result.embedderUnavailable).toBe(false);
+      expect(result.failed).toEqual([Q_A]);
+      expect(result.skipped.length).toBe(0);
+      expect(queue.items[0]?.attempts).toBe(1);
+    });
+
+    it("processes items BEFORE the unavailable trip and skips items AFTER", async () => {
+      // Item A succeeds, item B trips unavailable, item C is skipped.
+      let calls = 0;
+      const stubVector = embedder.vector;
+      embedder.embed = (text: string): Promise<EmbeddingVector> => {
+        calls += 1;
+        embedder.callCount = calls;
+        embedder.lastInput = text;
+        if (calls === 2) {
+          return Promise.reject(
+            new EmbedderUnavailableError("transient boom", {
+              retryAfterMs: 1500,
+            }),
+          );
+        }
+        return Promise.resolve(EmbeddingVector.create(stubVector));
+      };
+
+      const result = await useCase.drainBatch({
+        workspaceId: makeWorkspaceId(),
+        batchSize: 10,
+        backoffWindowMs: 30_000,
+      });
+
+      expect(result.processed).toEqual([Q_A]);
+      expect(result.embedderUnavailable).toBe(true);
+      expect(result.unavailableRetryAfterMs).toBe(1500);
+      // B tripped the unavailable, so B is skipped; C is also skipped.
+      expect(result.skipped).toEqual([Q_B, Q_C]);
+      // B and C still in queue with attempts=0.
+      const surviving = queue.items.filter(
+        (i) => i.id === Q_B || i.id === Q_C,
+      );
+      expect(surviving.length).toBe(2);
+      for (const item of surviving) {
+        expect(item.attempts).toBe(0);
+      }
+    });
+
+    it("keeps the unavailable signal when a permanent-failure row is followed by an unavailable trip", async () => {
+      // Items: A=permanent (attempts=5), B=transient unavailable, C=skipped.
+      queue.items = [
+        queueItem({ id: Q_A, targetRowId: ID_A, attempts: 5 }),
+        queueItem({ id: Q_B, targetRowId: ID_B, attempts: 0 }),
+        queueItem({ id: Q_C, targetRowId: ID_C, attempts: 0 }),
+      ];
+      // A is at MAX_ATTEMPTS so the loop logs "permanent failure" without
+      // calling embed. B is the first call to the embedder; trip on B.
+      let calls = 0;
+      embedder.embed = (): Promise<EmbeddingVector> => {
+        calls += 1;
+        embedder.callCount = calls;
+        return Promise.reject(
+          new EmbedderUnavailableError("model loading"),
+        );
+      };
+
+      const result = await useCase.drainBatch({
+        workspaceId: makeWorkspaceId(),
+        batchSize: 10,
+        backoffWindowMs: 30_000,
+      });
+
+      expect(result.permanentFailures).toEqual([Q_A]);
+      expect(result.embedderUnavailable).toBe(true);
+      expect(result.skipped).toEqual([Q_B, Q_C]);
+    });
   });
 });

--- a/code/tests/unit/retrieval/application/reset-embedding-queue.use-case.test.ts
+++ b/code/tests/unit/retrieval/application/reset-embedding-queue.use-case.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_RESET_THRESHOLD,
+  ResetEmbeddingQueueUseCase,
+} from "../../../../src/modules/retrieval/application/use-cases/reset-embedding-queue.use-case.ts";
+import type {
+  EmbeddingQueueItem,
+  EmbeddingQueueRepository,
+} from "../../../../src/modules/retrieval/application/ports/out/embedding-queue-repository.port.ts";
+import type { EmbeddingVector } from "../../../../src/modules/retrieval/domain/value-objects/embedding-vector.ts";
+import type { QueryKindValue } from "../../../../src/modules/retrieval/domain/value-objects/query-kind.ts";
+import type { Timestamp } from "../../../../src/shared/domain/value-objects/timestamp.ts";
+import type { WorkspaceId } from "../../../../src/shared/domain/value-objects/workspace-id.ts";
+import { makeWorkspaceId } from "../../../helpers/factories.ts";
+import { SilentLogger } from "../../../helpers/test-doubles.ts";
+
+class StubQueue implements EmbeddingQueueRepository {
+  public lastResetInput: {
+    workspaceId: WorkspaceId;
+    attemptsAtLeast: number;
+  } | null = null;
+  public resetReturn = 0;
+
+  public enqueue(): Promise<void> {
+    return Promise.resolve();
+  }
+  public dequeueBatch(): Promise<readonly EmbeddingQueueItem[]> {
+    return Promise.resolve([]);
+  }
+  public acknowledge(): Promise<void> {
+    return Promise.resolve();
+  }
+  public recordFailure(): Promise<void> {
+    return Promise.resolve();
+  }
+  public persistEmbedding(_input: {
+    workspaceId: WorkspaceId;
+    targetKind: QueryKindValue;
+    targetRowId: string;
+    embeddedText: string;
+    modelName: string;
+    vector: EmbeddingVector;
+    persistedAt: Timestamp;
+  }): Promise<void> {
+    return Promise.resolve();
+  }
+  public countPending(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  public resetPermanentFailures(input: {
+    workspaceId: WorkspaceId;
+    attemptsAtLeast: number;
+  }): Promise<number> {
+    this.lastResetInput = input;
+    return Promise.resolve(this.resetReturn);
+  }
+}
+
+let queue: StubQueue;
+let useCase: ResetEmbeddingQueueUseCase;
+
+beforeEach(() => {
+  queue = new StubQueue();
+  useCase = new ResetEmbeddingQueueUseCase(queue, new SilentLogger());
+});
+
+describe("ResetEmbeddingQueueUseCase", () => {
+  it("uses DEFAULT_RESET_THRESHOLD when caller omits attemptsAtLeast", async () => {
+    queue.resetReturn = 7;
+    const ws = makeWorkspaceId();
+
+    const result = await useCase.execute({ workspaceId: ws });
+
+    expect(result.attemptsAtLeast).toBe(DEFAULT_RESET_THRESHOLD);
+    expect(result.attemptsAtLeast).toBe(5);
+    expect(result.resetCount).toBe(7);
+    expect(queue.lastResetInput?.attemptsAtLeast).toBe(5);
+    expect(queue.lastResetInput?.workspaceId.toString()).toBe(ws.toString());
+  });
+
+  it("forwards a custom threshold to the repository", async () => {
+    queue.resetReturn = 2;
+    const ws = makeWorkspaceId();
+
+    const result = await useCase.execute({
+      workspaceId: ws,
+      attemptsAtLeast: 3,
+    });
+
+    expect(result.attemptsAtLeast).toBe(3);
+    expect(result.resetCount).toBe(2);
+    expect(queue.lastResetInput?.attemptsAtLeast).toBe(3);
+  });
+
+  it("returns a frozen result object", async () => {
+    const result = await useCase.execute({ workspaceId: makeWorkspaceId() });
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  it("returns resetCount=0 when no rows met the threshold", async () => {
+    queue.resetReturn = 0;
+    const result = await useCase.execute({ workspaceId: makeWorkspaceId() });
+    expect(result.resetCount).toBe(0);
+  });
+});

--- a/code/tests/unit/retrieval/infrastructure/async-embedding-worker.test.ts
+++ b/code/tests/unit/retrieval/infrastructure/async-embedding-worker.test.ts
@@ -17,6 +17,36 @@ interface DrainCall {
   readonly backoffWindowMs: number;
 }
 
+const emptyResult = (): EmbedAndPersistResult => ({
+  processed: [],
+  failed: [],
+  permanentFailures: [],
+  embedderUnavailable: false,
+  unavailableRetryAfterMs: null,
+  skipped: [],
+});
+
+const processedResult = (
+  ids: readonly string[],
+): EmbedAndPersistResult => ({
+  ...emptyResult(),
+  processed: ids,
+});
+
+const unavailableResult = (
+  options: {
+    skipped?: readonly string[];
+    retryAfterMs?: number | null;
+    processed?: readonly string[];
+  } = {},
+): EmbedAndPersistResult => ({
+  ...emptyResult(),
+  processed: options.processed ?? [],
+  embedderUnavailable: true,
+  unavailableRetryAfterMs: options.retryAfterMs ?? null,
+  skipped: options.skipped ?? [],
+});
+
 class StubUseCase
   implements Pick<EmbedAndPersistUseCase, "drainBatch">
 {
@@ -28,9 +58,7 @@ class StubUseCase
     this.calls.push(input);
     if (this.error !== null) return Promise.reject(this.error);
     const next = this.results.shift();
-    return Promise.resolve(
-      next ?? { processed: [], failed: [], permanentFailures: [] },
-    );
+    return Promise.resolve(next ?? emptyResult());
   }
 }
 
@@ -40,6 +68,8 @@ const newWorker = (
     batchSize: number;
     backoffWindowMs: number;
     idlePollMs: number;
+    unavailableBackoffInitialMs: number;
+    maxUnavailableBackoffMs: number;
   }> = {},
 ): AsyncEmbeddingWorker =>
   new AsyncEmbeddingWorker(uc as unknown as EmbedAndPersistUseCase, {
@@ -47,6 +77,8 @@ const newWorker = (
     batchSize: options.batchSize,
     backoffWindowMs: options.backoffWindowMs,
     idlePollMs: options.idlePollMs,
+    unavailableBackoffInitialMs: options.unavailableBackoffInitialMs,
+    maxUnavailableBackoffMs: options.maxUnavailableBackoffMs,
     logger: new SilentLogger(),
   });
 
@@ -94,9 +126,9 @@ describe("AsyncEmbeddingWorker", () => {
   it("immediately re-drains when there is work (processedCount > 0)", async () => {
     const uc = new StubUseCase();
     uc.results = [
-      { processed: ["q1"], failed: [], permanentFailures: [] },
-      { processed: ["q2"], failed: [], permanentFailures: [] },
-      { processed: [], failed: [], permanentFailures: [] },
+      processedResult(["q1"]),
+      processedResult(["q2"]),
+      emptyResult(),
     ];
     const worker = newWorker(uc, { idlePollMs: 5_000 });
 
@@ -205,9 +237,7 @@ describe("AsyncEmbeddingWorker", () => {
 
   it("does not re-schedule once stopped (running flag respected)", async () => {
     const uc = new StubUseCase();
-    uc.results = [
-      { processed: ["q1"], failed: [], permanentFailures: [] },
-    ];
+    uc.results = [processedResult(["q1"])];
     const worker = newWorker(uc, { idlePollMs: 50 });
 
     worker.start();
@@ -219,5 +249,146 @@ describe("AsyncEmbeddingWorker", () => {
     const totalAfter = uc.calls.length;
     await vi.advanceTimersByTimeAsync(1000);
     expect(uc.calls.length).toBe(totalAfter);
+  });
+
+  // ─── B-MCP-7: back-off on embedderUnavailable ─────────────────────────
+
+  describe("embedderUnavailable back-off (B-MCP-7)", () => {
+    it("waits the configured initial back-off after a single unavailable batch", async () => {
+      const uc = new StubUseCase();
+      uc.results = [
+        unavailableResult({ skipped: ["a", "b"] }),
+        emptyResult(),
+      ];
+      const worker = newWorker(uc, {
+        idlePollMs: 200,
+        unavailableBackoffInitialMs: 1_000,
+      });
+
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(uc.calls.length).toBe(1);
+
+      // After the unavailable batch the worker MUST wait 1 000 ms (NOT
+      // the 200 ms idle poll). Verify the next drain is gated.
+      await vi.advanceTimersByTimeAsync(999);
+      expect(uc.calls.length).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(uc.calls.length).toBe(2);
+
+      await worker.stop();
+    });
+
+    it("doubles the back-off on consecutive unavailable batches", async () => {
+      const uc = new StubUseCase();
+      uc.results = [
+        unavailableResult(), // call 1 → wait 1000 ms
+        unavailableResult(), // call 2 → wait 2000 ms
+        unavailableResult(), // call 3 → wait 4000 ms
+        emptyResult(),
+      ];
+      const worker = newWorker(uc, {
+        idlePollMs: 200,
+        unavailableBackoffInitialMs: 1_000,
+        maxUnavailableBackoffMs: 60_000,
+      });
+
+      worker.start();
+      // First drain (call 1) — runs immediately.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(uc.calls.length).toBe(1);
+
+      // Wait 1 000 ms → call 2 fires.
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(uc.calls.length).toBe(2);
+
+      // Wait 2 000 ms → call 3 fires.
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(uc.calls.length).toBe(3);
+
+      // Wait 4 000 ms → call 4 fires (this one returns empty result).
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(uc.calls.length).toBe(4);
+
+      await worker.stop();
+    });
+
+    it("caps the exponential back-off at maxUnavailableBackoffMs", async () => {
+      const uc = new StubUseCase();
+      // Pile up enough unavailable results that the exponential schedule
+      // would exceed the cap (initial 1 000, max 5 000 → caps at call 4).
+      uc.results = Array.from({ length: 8 }, () => unavailableResult());
+      const worker = newWorker(uc, {
+        unavailableBackoffInitialMs: 1_000,
+        maxUnavailableBackoffMs: 5_000,
+      });
+
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0); // call 1
+      await vi.advanceTimersByTimeAsync(1_000); // call 2 (1 000 ms back-off)
+      await vi.advanceTimersByTimeAsync(2_000); // call 3 (2 000 ms back-off)
+      await vi.advanceTimersByTimeAsync(4_000); // call 4 (would be 4 000 ms; under cap)
+      // From here every back-off should be capped at 5 000 ms.
+      const callsBeforeCap = uc.calls.length;
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(uc.calls.length).toBe(callsBeforeCap);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(uc.calls.length).toBe(callsBeforeCap + 1);
+
+      await worker.stop();
+    });
+
+    it("prefers the use case's per-call retry hint over exponential schedule", async () => {
+      const uc = new StubUseCase();
+      uc.results = [
+        unavailableResult({ retryAfterMs: 4_000 }),
+        emptyResult(),
+      ];
+      const worker = newWorker(uc, {
+        unavailableBackoffInitialMs: 1_000,
+      });
+
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(uc.calls.length).toBe(1);
+
+      // 1 000 ms (initial back-off) is NOT enough — the hint asked for
+      // 4 000 ms.
+      await vi.advanceTimersByTimeAsync(3_999);
+      expect(uc.calls.length).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(uc.calls.length).toBe(2);
+
+      await worker.stop();
+    });
+
+    it("resets the back-off streak after a recovered batch", async () => {
+      const uc = new StubUseCase();
+      uc.results = [
+        unavailableResult(), // burns 1 attempt → back-off 1 000 ms
+        unavailableResult(), // burns 2nd → back-off 2 000 ms
+        emptyResult(), // recovers
+        unavailableResult(), // back-off should be 1 000 ms again, NOT 4 000 ms
+        emptyResult(),
+      ];
+      const worker = newWorker(uc, {
+        idlePollMs: 200,
+        unavailableBackoffInitialMs: 1_000,
+      });
+
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0); // call 1
+      await vi.advanceTimersByTimeAsync(1_000); // call 2 (1 000 ms)
+      await vi.advanceTimersByTimeAsync(2_000); // call 3 (2 000 ms) → recovers
+      // Recovered batch returned empty processed → idle poll (200 ms).
+      await vi.advanceTimersByTimeAsync(200); // call 4 (idle poll, unavailable again)
+      // After call 4 (unavailable), streak reset means initial 1 000 ms.
+      await vi.advanceTimersByTimeAsync(999);
+      expect(uc.calls.length).toBe(4);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(uc.calls.length).toBe(5);
+
+      await worker.stop();
+    });
   });
 });

--- a/code/tests/unit/retrieval/infrastructure/async-embedding-worker.test.ts
+++ b/code/tests/unit/retrieval/infrastructure/async-embedding-worker.test.ts
@@ -191,6 +191,20 @@ describe("AsyncEmbeddingWorker", () => {
     await worker.stop();
   });
 
+  it("recovers from a non-Error rejection (covers String() coercion path)", async () => {
+    const uc = new StubUseCase();
+    // Reject with a primitive, NOT an Error instance — this exercises
+    // the `String(cause)` branch of the worker's logger payload.
+    uc.error = "synthetic-string-rejection" as unknown as Error;
+    const worker = newWorker(uc, { idlePollMs: 100 });
+
+    worker.start();
+    await vi.runOnlyPendingTimersAsync();
+    expect(uc.calls.length).toBeGreaterThanOrEqual(1);
+
+    await worker.stop();
+  });
+
   it("start() is a no-op when already running", async () => {
     const uc = new StubUseCase();
     const worker = newWorker(uc);

--- a/code/tests/unit/retrieval/infrastructure/raw-embedder-adapter.test.ts
+++ b/code/tests/unit/retrieval/infrastructure/raw-embedder-adapter.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { RawEmbedderAdapter } from "../../../../src/modules/retrieval/infrastructure/embedder/raw-embedder-adapter.ts";
+import { EmbedFailedError } from "../../../../src/modules/retrieval/domain/errors/embed-failed-error.ts";
+import { EmbedderUnavailableError } from "../../../../src/modules/retrieval/domain/errors/embedder-unavailable-error.ts";
 import { EmbeddingVector } from "../../../../src/modules/retrieval/domain/value-objects/embedding-vector.ts";
+import { RawEmbedderAdapter } from "../../../../src/modules/retrieval/infrastructure/embedder/raw-embedder-adapter.ts";
 import type {
   Embedder as RawEmbedderPort,
   RawEmbedding,
 } from "../../../../src/shared/application/ports/embedder.port.ts";
+import { EmbedderError } from "../../../../src/shared/infrastructure/errors/embedder-error.ts";
 
 class StubRawEmbedder implements RawEmbedderPort {
   public lastTexts: string[] = [];
@@ -104,7 +107,7 @@ describe("RawEmbedderAdapter", () => {
     expect(Object.isFrozen(out)).toBe(true);
   });
 
-  it("throws when raw embedding lies about its dimension", async () => {
+  it("throws EmbedFailedError when raw embedding lies about its dimension", async () => {
     // dimension says 5 but vector length is 3 — the adapter MUST detect.
     const raw: RawEmbedderPort = {
       embed: (): Promise<RawEmbedding> =>
@@ -116,31 +119,110 @@ describe("RawEmbedderAdapter", () => {
       dimension: () => 5,
     };
     const adapter = new RawEmbedderAdapter(raw);
+    await expect(adapter.embed("x")).rejects.toBeInstanceOf(EmbedFailedError);
     await expect(adapter.embed("x")).rejects.toThrow(
       /vector of length 3.*dimension 5/i,
     );
   });
 
-  it("propagates errors from the raw embedder unchanged", async () => {
-    const raw: RawEmbedderPort = {
-      embed: (): Promise<RawEmbedding> =>
-        Promise.reject(new Error("backend down")),
-      embedBatch: (): Promise<readonly RawEmbedding[]> => Promise.resolve([]),
-      dimension: () => 3,
-    };
-    const adapter = new RawEmbedderAdapter(raw);
-    await expect(adapter.embed("x")).rejects.toThrow(/backend down/);
-  });
+  // ─── B-MCP-7: typed-error translation layer ───────────────────────────
 
-  it("propagates errors from raw embedBatch unchanged", async () => {
-    const raw: RawEmbedderPort = {
-      embed: (): Promise<RawEmbedding> =>
-        Promise.resolve(fixed(new Float32Array([1]))),
-      embedBatch: (): Promise<readonly RawEmbedding[]> =>
-        Promise.reject(new Error("batch failed")),
-      dimension: () => 1,
-    };
-    const adapter = new RawEmbedderAdapter(raw);
-    await expect(adapter.embedBatch(["x"])).rejects.toThrow(/batch failed/);
+  describe("B-MCP-7 typed error translation", () => {
+    it("wraps EmbedderError(initialisation-failed) as EmbedderUnavailableError", async () => {
+      const raw: RawEmbedderPort = {
+        embed: (): Promise<RawEmbedding> =>
+          Promise.reject(
+            EmbedderError.initialisationFailed(new Error("download timed out")),
+          ),
+        embedBatch: (): Promise<readonly RawEmbedding[]> =>
+          Promise.resolve([]),
+        dimension: () => 3,
+      };
+      const adapter = new RawEmbedderAdapter(raw);
+      const err = await adapter.embed("x").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(EmbedderUnavailableError);
+      const unavailable = err as EmbedderUnavailableError;
+      expect(unavailable.code).toBe("retrieval.embedder-unavailable");
+      // The shared cause is preserved on the domain error so callers
+      // that introspect it (e.g. logs) still see the original message.
+      expect(unavailable.cause).toBeInstanceOf(EmbedderError);
+      // No retry hint by default — the worker picks its own back-off.
+      expect(unavailable.retryAfterMs).toBeNull();
+    });
+
+    it("wraps EmbedderError(not-initialised) as EmbedderUnavailableError", async () => {
+      const raw: RawEmbedderPort = {
+        embed: (): Promise<RawEmbedding> =>
+          Promise.reject(EmbedderError.notInitialised("dimension")),
+        embedBatch: (): Promise<readonly RawEmbedding[]> =>
+          Promise.resolve([]),
+        dimension: () => 3,
+      };
+      const adapter = new RawEmbedderAdapter(raw);
+      const err = await adapter.embed("x").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(EmbedderUnavailableError);
+    });
+
+    it("wraps EmbedderError(embed-failed) as EmbedFailedError", async () => {
+      const raw: RawEmbedderPort = {
+        embed: (): Promise<RawEmbedding> =>
+          Promise.reject(
+            EmbedderError.embedFailed(new Error("input rejected by tokenizer")),
+          ),
+        embedBatch: (): Promise<readonly RawEmbedding[]> =>
+          Promise.resolve([]),
+        dimension: () => 3,
+      };
+      const adapter = new RawEmbedderAdapter(raw);
+      const err = await adapter.embed("x").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(EmbedFailedError);
+      // Specifically NOT an unavailable error — per-item rejections stay
+      // per-item so the worker bumps attempts as before.
+      expect(err).not.toBeInstanceOf(EmbedderUnavailableError);
+    });
+
+    it("wraps EmbedderError(dimension-mismatch) as EmbedFailedError", async () => {
+      const raw: RawEmbedderPort = {
+        embed: (): Promise<RawEmbedding> =>
+          Promise.reject(EmbedderError.dimensionMismatch(384, 768)),
+        embedBatch: (): Promise<readonly RawEmbedding[]> =>
+          Promise.resolve([]),
+        dimension: () => 384,
+      };
+      const adapter = new RawEmbedderAdapter(raw);
+      await expect(adapter.embed("x")).rejects.toBeInstanceOf(
+        EmbedFailedError,
+      );
+    });
+
+    it("wraps a non-EmbedderError cause as EmbedFailedError (conservative default)", async () => {
+      // Defaulting to per-item failure means a misbehaving adapter cannot
+      // accidentally trigger the worker-wide back-off.
+      const raw: RawEmbedderPort = {
+        embed: (): Promise<RawEmbedding> =>
+          Promise.reject(new Error("backend down")),
+        embedBatch: (): Promise<readonly RawEmbedding[]> =>
+          Promise.resolve([]),
+        dimension: () => 3,
+      };
+      const adapter = new RawEmbedderAdapter(raw);
+      const err = await adapter.embed("x").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(EmbedFailedError);
+      expect((err as EmbedFailedError).message).toMatch(/backend down/);
+    });
+
+    it("translates errors thrown from embedBatch as well", async () => {
+      const raw: RawEmbedderPort = {
+        embed: (): Promise<RawEmbedding> =>
+          Promise.resolve(fixed(new Float32Array([1]))),
+        embedBatch: (): Promise<readonly RawEmbedding[]> =>
+          Promise.reject(EmbedderError.initialisationFailed(undefined)),
+        dimension: () => 1,
+      };
+      const adapter = new RawEmbedderAdapter(raw);
+      await expect(adapter.embedBatch(["x"])).rejects.toBeInstanceOf(
+        EmbedderUnavailableError,
+      );
+    });
   });
 });

--- a/code/tests/unit/retrieval/infrastructure/raw-embedder-adapter.test.ts
+++ b/code/tests/unit/retrieval/infrastructure/raw-embedder-adapter.test.ts
@@ -224,5 +224,25 @@ describe("RawEmbedderAdapter", () => {
         EmbedderUnavailableError,
       );
     });
+
+    it("wraps a non-Error rejection (e.g. string) as EmbedFailedError using String() coercion", async () => {
+      // Misbehaving adapters can reject with non-Error values (string,
+      // plain object, etc.). The translation layer MUST handle this to
+      // avoid leaking `undefined.message` errors to the caller.
+      const raw: RawEmbedderPort = {
+        embed: (): Promise<RawEmbedding> =>
+          // deliberately reject with a primitive
+          Promise.reject("legacy adapter threw a string"),
+        embedBatch: (): Promise<readonly RawEmbedding[]> =>
+          Promise.resolve([]),
+        dimension: () => 3,
+      };
+      const adapter = new RawEmbedderAdapter(raw);
+      const err = await adapter.embed("x").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(EmbedFailedError);
+      expect((err as EmbedFailedError).message).toBe(
+        "legacy adapter threw a string",
+      );
+    });
   });
 });

--- a/code/tests/unit/retrieval/infrastructure/sqlite-embedding-queue-repository.test.ts
+++ b/code/tests/unit/retrieval/infrastructure/sqlite-embedding-queue-repository.test.ts
@@ -340,6 +340,87 @@ describe("SqliteEmbeddingQueueRepository - queue", () => {
     expect(Object.isFrozen(items)).toBe(true);
     expect(items.length).toBe(0);
   });
+
+  // ─── B-MCP-7: resetPermanentFailures (recall reset-queue) ─────────────
+
+  describe("resetPermanentFailures (B-MCP-7)", () => {
+    it("clears attempts and last_error on rows at or above the threshold", async () => {
+      const ws = makeWorkspaceId();
+      // Seed: 2 perma-failed rows + 1 partially-failed row (attempts=3) +
+      // 1 untouched row.
+      db.prepare(
+        "INSERT INTO embedding_queue (id, workspace_id, target_kind, target_row_id, enqueued_at_ms, attempts, last_error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("q-perm-1", ws.toString(), "decision", "r1", ANCHOR_TIME_MS, 5, "fastembed init failed");
+      db.prepare(
+        "INSERT INTO embedding_queue (id, workspace_id, target_kind, target_row_id, enqueued_at_ms, attempts, last_error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("q-perm-2", ws.toString(), "learning", "r2", ANCHOR_TIME_MS, 6, "model not loaded");
+      db.prepare(
+        "INSERT INTO embedding_queue (id, workspace_id, target_kind, target_row_id, enqueued_at_ms, attempts, last_error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("q-mid", ws.toString(), "decision", "r3", ANCHOR_TIME_MS, 3, "transient");
+      db.prepare(
+        "INSERT INTO embedding_queue (id, workspace_id, target_kind, target_row_id, enqueued_at_ms, attempts, last_error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("q-fresh", ws.toString(), "entity", "r4", ANCHOR_TIME_MS, 0, null);
+
+      const updated = await repo.resetPermanentFailures({
+        workspaceId: ws,
+        attemptsAtLeast: 5,
+      });
+      expect(updated).toBe(2);
+
+      const rowsById = (id: string): { attempts: number; last_error: string | null } =>
+        db
+          .prepare("SELECT attempts, last_error FROM embedding_queue WHERE id = ?")
+          .get(id) as { attempts: number; last_error: string | null };
+
+      expect(rowsById("q-perm-1").attempts).toBe(0);
+      expect(rowsById("q-perm-1").last_error).toBeNull();
+      expect(rowsById("q-perm-2").attempts).toBe(0);
+      expect(rowsById("q-perm-2").last_error).toBeNull();
+      // Mid-attempt row untouched.
+      expect(rowsById("q-mid").attempts).toBe(3);
+      expect(rowsById("q-mid").last_error).toBe("transient");
+      // Fresh row untouched.
+      expect(rowsById("q-fresh").attempts).toBe(0);
+    });
+
+    it("returns 0 when no rows meet the threshold", async () => {
+      const ws = makeWorkspaceId();
+      db.prepare(
+        "INSERT INTO embedding_queue (id, workspace_id, target_kind, target_row_id, enqueued_at_ms, attempts, last_error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("q-fresh", ws.toString(), "decision", "r1", ANCHOR_TIME_MS, 1, null);
+
+      const updated = await repo.resetPermanentFailures({
+        workspaceId: ws,
+        attemptsAtLeast: 5,
+      });
+      expect(updated).toBe(0);
+    });
+
+    it("scopes the reset to the requested workspaceId", async () => {
+      const wsA = makeWorkspaceId();
+      const wsB = "01952f3b-7d8c-7000-8000-bbbbbbbbbbbb";
+
+      db.prepare(
+        "INSERT INTO embedding_queue (id, workspace_id, target_kind, target_row_id, enqueued_at_ms, attempts, last_error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("q-a", wsA.toString(), "decision", "rA", ANCHOR_TIME_MS, 5, "boom");
+      db.prepare(
+        "INSERT INTO embedding_queue (id, workspace_id, target_kind, target_row_id, enqueued_at_ms, attempts, last_error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("q-b", wsB, "decision", "rB", ANCHOR_TIME_MS, 5, "boom");
+
+      const updated = await repo.resetPermanentFailures({
+        workspaceId: wsA,
+        attemptsAtLeast: 5,
+      });
+      expect(updated).toBe(1);
+
+      // wsB row UNTOUCHED — defence in depth on top of schema-level scope.
+      const otherRow = db
+        .prepare("SELECT attempts, last_error FROM embedding_queue WHERE id = ?")
+        .get("q-b") as { attempts: number; last_error: string | null };
+      expect(otherRow.attempts).toBe(5);
+      expect(otherRow.last_error).toBe("boom");
+    });
+  });
 });
 
 describe("SqliteEmbeddingQueueRepository - persistEmbedding", () => {


### PR DESCRIPTION
Closes [#24](https://github.com/NetziTech/recall/issues/24).

## Problem

The `AsyncEmbeddingWorker` (wired by B-MCP-3 in `0.1.2-beta.3`) treated every `embed()` rejection as a per-item failure and bumped `attempts` on the queue row. During a fastembed cold-start (~4.3 s `FlagEmbedding.init()` or a fast-failing init from a corrupt cache / network outage), the worker would burn through `MAX_ATTEMPTS=5` on each row in milliseconds, leaving 32 items at `attempts=5` permanent failure before the model was ready.

Surface symptom in dogfood (HANDOFF §6.17): `mem.recall` paraphrased queries fall back to `fallback_reason: \"embedder_unavailable\"` indefinitely; semantic recall is broken even though B-MCP-3 is fixed.

## Fix (Option A from issue) — typed error union

| Layer | Change |
|---|---|
| Domain | New errors `EmbedderUnavailableError` (transport-level) and `EmbedFailedError` (per-input). |
| Adapter | `RawEmbedderAdapter` translates the shared `EmbedderError` codes onto the new domain types: `embedder.initialisation-failed` / `embedder.not-initialised` → unavailable; `embedder.embed-failed` / `embedder.dimension-mismatch` and unknown causes → per-item (conservative default). |
| Use case | `EmbedAndPersistUseCase` switches: on unavailable, **aborts the batch without calling `recordFailure` on any item** and returns `embedderUnavailable: true` + `unavailableRetryAfterMs` + `skipped[]`; on per-item, bumps attempts as before. |
| Worker | `AsyncEmbeddingWorker` reads the new flag and applies exponential back-off (1 s → 2 s → 4 s → 8 s, capped at 60 s by default; honours per-call hint). Streak resets on the first non-unavailable batch. |

## Recovery (Option C from issue) — `recall reset-queue`

For workspaces already poisoned by the pre-fix worker:

- `EmbeddingQueueRepository.resetPermanentFailures(workspaceId, attemptsAtLeast)` — atomic per-workspace UPDATE clearing `attempts` + `last_error`.
- `ResetEmbeddingQueueUseCase` (retrieval/application).
- `recall reset-queue [--threshold <n>]` CLI command (default threshold = 5). Idempotent.

## Test coverage (+31 tests, 2550/2550 passing)

| Layer | New tests |
|---|---|
| `EmbedAndPersistUseCase` | +5: unavailable path (no `recordFailure`, skipped list, mixed permanent + unavailable) |
| `AsyncEmbeddingWorker` | +5: initial back-off, exponential ramp, max cap, per-call hint, streak reset on recovery |
| `RawEmbedderAdapter` | +6: typed-error translation matrix (4 EmbedderError codes + non-EmbedderError + embedBatch path) |
| `SqliteEmbeddingQueueRepository.resetPermanentFailures` | +3: above-threshold reset with VALUES check, no-ops, workspace scoping |
| `ResetEmbeddingQueueUseCase` | +4: defaults, custom threshold, frozen result, zero-row case |
| `ResetQueueCommandHandler` | +4: forward inputs, custom threshold, zero-row message, command discriminator |
| `CommanderCliParser` (`reset-queue`) | +3: no-flag, positive integer, invalid input |
| Integration `O-embedder-cold-start.test.ts` | +2: cold-start tolerance via `nextErrors` queue + post-recovery reset path |

## Validation

- [x] `npm run typecheck` — EXIT 0
- [x] `npm run lint` — EXIT 0
- [x] `npm run validate:modules` — EXIT 0
- [x] `npm test` — 2550/2550 passing (+31 vs baseline 2519)
- [x] `npm run build` — EXIT 0 (cli.js + server.js, ~862 KB each)

## Architecture compliance

- Domain errors live in `retrieval/domain/errors/` (Hexagonal direction-of-dependency respected: `shared/infrastructure` errors are translated at the adapter seam, never imported into the domain).
- New CLI command follows the existing pattern (catalog → DTO discriminated union → handler implementing `CommandHandler<TCommand>` → facade port → adapter in composition root → parser registration).
- Module boundaries unchanged: `cli` ↔ `retrieval` flow goes via the composition root facade (no direct cross-module import).

## Caveats

- Test methodology Phase-9 \"VALORES no SHAPE\" reinforced: integration test asserts the `attempts` column stays at 0 throughout the cold-start window AND the queue drains after recovery — a pre-fix worker would have all 3 rows at `attempts=5` after the first batch.
- The `recall reset-queue` command is for users on `<= 0.1.2-beta.3` who already have perma-failed rows; new installs on `>= 0.1.2-beta.4` should never need it.

## Out of scope (deferred)

- Cosmetic stale row in HANDOFF.md §0 (\"Workflow Claude (settings.json hooks)\" still says PENDIENTE) — fixed separately when Phase-13 closes.
- Smoke test against the real fastembed cold-start: requires CI cache cleanup + ~30 MB download per run; deferred until we have a tagged-skip strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)