### PR TITLE
docs(handoff): close Phase-13 — B-MCP-7 fix + claude-hooks + SonarQube tooling

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -14,28 +14,28 @@
 
 | Item | Estado |
 |---|---|
-| **Fecha del handoff** | 2026-05-01 noche (post-Phase-12 cerrado — `@netzi/recall@0.1.2-beta.3` PUBLICADO en npm beta channel, 4 bugs originales cerrados, **1 bug nuevo descubierto en smoke post-publish** (B-MCP-7, issue #24). Ver §6.17) |
+| **Fecha del handoff** | 2026-05-02 (post-Phase-13 cerrado — B-MCP-7 fix mergeado a develop via PR [#27](https://github.com/NetziTech/recall/pull/27), workflow Claude hooks shipped via PR [#26](https://github.com/NetziTech/recall/pull/26), 0 issues abiertos, listo para cortar `release/0.1.2-beta.4`. Ver §6.18) |
 | **Producto** | Servidor MCP de memoria persistente por proyecto, viviendo dentro del proyecto (`<repo>/.recall/`), con 3 modos: compartido / encriptado / privado |
-| **Fase actual** | **`@netzi/recall@0.1.2-beta.3` PUBLICADO en npm beta channel.** Smoke post-publish valido los 4 fixes de Phase-11 contra DB real del dogfood: B-MCP-2 ✅ (`mem.health` con valores reales: `total_entries=64`, `mode="private"`, etc.), B-MCP-4 ✅ (migration 008 corrio sobre la DB existente, `schema_version=8`), BM25 lexical ✅ (recall con query "GitFlow" → 2 hits), B-MCP-3 wiring ✅ (log `"embedding worker started"`). Pero **descubierto nuevo bug B-MCP-7 (high)**: el worker burnea 5 retries en milisegundos durante el cold-start de fastembed (~4.3s init), dejando items en `attempts=5` permanent failure antes de que el modelo termine de cargar. Issue [#24](https://github.com/NetziTech/recall/issues/24) abierto. Proximo paso: cerrar B-MCP-7 en `v0.1.2-beta.4` antes de promover a `0.1.2` stable. |
-| **Lineas de codigo** | ~59,400 en `code/src/` + ~34,400 LOC de tests en **208 archivos test**. 8 modulos + shared + composition + bootstrap. **Phase-11 deltas**: +~600 LOC src (worker wiring, WorkspaceStateReader port + adapter, DecisionContent VO, decision content end-to-end), +3 archivos test value-validation (L/M/N). |
+| **Fase actual** | **`develop` listo para cortar `release/0.1.2-beta.4`.** B-MCP-7 cerrado: typed error union (`EmbedderUnavailableError` vs `EmbedFailedError`) + worker exponential back-off + `recall reset-queue` CLI command para recovery. PRs squash-merged a develop: #27 (B-MCP-7 fix, +31 archivos / +1929 LOC) + #26 (claude-hooks pre-commit `PreToolUse` Bash hooks, ataja commits a branch protegida en local). SonarQube quality gate **PASSED** post-fix de 1 critical S3776 (cognitive complexity de `drainBatch` 17→5 via extract method) + 3 minor S7735 (negated conditions invertidas). Tests 2553/2553 passing. Proximo paso: cortar `release/0.1.2-beta.4` (bump `package.json` + `sonar-project.properties` + nuevo `RELEASE-NOTES-v0.1.2-beta.4.md` + actualizar README/SECURITY), publish en npm `--tag beta`, smoke contra DB del dogfood validando que el worker drena la cola post-fix. |
+| **Lineas de codigo** | ~61,000 en `code/src/` + ~36,000 LOC de tests en **213 archivos test**. 8 modulos + shared + composition + bootstrap. **Phase-13 deltas (PR #27)**: +~1,500 LOC src (typed error union retrieval/domain/errors/, ResetEmbeddingQueueUseCase, worker back-off + extract-method refactor, RawEmbedderAdapter typed translation, EmbeddingQueueFacade port + reset-queue CLI handler/parser/wiring), +5 archivos test (O-embedder-cold-start integration + reset-embedding-queue + embedding-queue-handlers + augmentos a embed-and-persist/raw-embedder/sqlite-queue + worker). |
 | **Migraciones** | **9** en `code/migrations/` (000__bootstrap, 001__secret-audit-log, 002__retrieval-schema, 003__pruned-and-curator-runs, 004__core-memory-schema, 005__perf-indexes, 006__workspace-config-table, 007__fts-trigger-column-scope, **008__decisions-content** — backfill rationale → content + rebuild FTS5 con la columna nueva). |
-| **Lineas de documentacion** | ~7,900 en `docs/` (incluye ADR-001..004, convencion `.port.ts` §3.1). 4 release notes (`RELEASE-NOTES-v0.1.0.md`, `v0.1.1.md`, `v0.1.2-beta.0.md`, `v0.1.2-beta.3.md`). docs/02 §4.3 documenta `min_score`. |
+| **Lineas de documentacion** | ~7,900 en `docs/` (incluye ADR-001..004, convencion `.port.ts` §3.1). 4 release notes (`RELEASE-NOTES-v0.1.0.md`, `v0.1.1.md`, `v0.1.2-beta.0.md`, `v0.1.2-beta.3.md`); `RELEASE-NOTES-v0.1.2-beta.4.md` se crea al cortar el release branch. docs/02 §4.3 documenta `min_score`. |
 | **Agentes definidos** | 13 en `.claude/agents/` (1 orquestador + 6 implementadores + 6 validadores). |
 | **Reportes de validacion** | 71 historicos del MVP (Fases 1-6) + Phase-7/8/9 validadas con los 5 checks objetivos (typecheck/lint/validate:modules/build/test) por sub-fase, sin reportes formales nuevos. |
 | **Tooling materializado** | `code/package.json` (eslint 10.2.1, commander 14.0.3, actions/checkout@v6, actions/setup-node@v6 tras auto-merges Phase-10), `code/tsconfig.json` (17 flags estrictos), `code/eslint.config.js` (ESLint 9 strict; tests/scripts override ahora con `argsIgnorePattern: "^_"`), `code/vitest.config.ts` (thresholds locales 95%/100%/100%/90%; **deferidos a SonarQube en CI** via `process.env.CI` switch), `code/scripts/validate-modules.ts`, `code/sonar-project.properties` (key `recall`, version `0.1.2-beta.0`), `code/tsup.config.ts`. **Nuevo Phase-10**: `.github/workflows/ci.yml`, `.github/dependabot.yml`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/*` (bug + feature + config), `CONTRIBUTING.md`, `SECURITY.md`. |
-| **SonarQube** | https://sonar.netzi.dev/dashboard?id=recall — proyecto **renombrado** de `mcp-memoria-inteligente` → `recall` via API (preserva UUID + historial). Quality gate `MCP Memoria Strict` **PASSED ciclo final Phase-10** post-fix de 4 violations heredadas de Phase-7/8/9 (3x S3735 `void` operator + 1x S7746 `Promise.resolve(value)` redundante + 2x S7758 `charCodeAt` → `codePointAt`). Coverage 96.4%, ratings A en reliability/security/maintainability/security-review, **0 bugs / 0 vulns / 0 blockers / 0 critical**, sqale_debt_ratio 0.1%. **CI corre el gate en cada PR/push** desde Phase-10. |
-| **Tests** | **2519 passing** en 208 archivos test (+18 vs beta.0; +3 archivos: L-embedding-worker-drains, M-mem-health-real-state, N-decision-content-roundtrip — todos VALUES-validation). Coverage SonarQube se mantiene >=95%. La regla "VALORES no SHAPE" de Phase-9 se aplica en cada nuevo test. |
+| **SonarQube** | https://sonar.netzi.dev/dashboard?id=recall — proyecto **renombrado** de `mcp-memoria-inteligente` → `recall` via API (preserva UUID + historial). Quality gate `MCP Memoria Strict` **PASSED Phase-13** post-fix de 4 nuevas violations introducidas por PR #27 antes del refactor (1 critical S3776 `drainBatch` complexity 17→ ≤15 via 8 metodos extraidos; 3 minor S7735 negated conditions invertidas en `cli-facades` + dos domain errors). Coverage **new 99.8% / overall 96.4%**, ratings A en reliability/security/maintainability/security-review, **0 bugs / 0 vulns / 0 blockers / 0 critical / 0 violations en new code**, sqale_debt_ratio 0.0%. **CI corre el gate en cada PR/push** desde Phase-10. **Token rotation Phase-13**: `recall-ci-2026-04-28` (Project) + `recall-ci-global-2026-04-28` (Global) + `mcp-memoria-setup` (User) revocados; nuevo `ci-github-actions-recall` (Project Analysis Token, scoped a recall, expira 2026-08-02) en GitHub Secret `SONAR_TOKEN`. Token User `claude-debug` en `~/.netzi-secrets/sonar.env` (0600) para queries API directas (memoria reference). |
+| **Tests** | **2553 passing** en 213 archivos test (+34 vs beta.3; +2 archivos: O-embedder-cold-start (integration, B-MCP-7 regression) + reset-embedding-queue.use-case + embedding-queue-handlers + augmentos en embed-and-persist (15 tests) / raw-embedder (14) / async-embedding-worker (17) / sqlite-embedding-queue (16)). Coverage SonarQube **new code 99.8% / overall 96.4%**. La regla "VALORES no SHAPE" reforzada: O-embedder-cold-start asserta que `attempts` permanece en 0 durante el cold-start window simulado (NO basta con asertar el shape del result). |
 | **Benchmarks** | 4/6 PASS (mem.remember 0.18ms p95, mem.recall 1.51ms p95, mem.context 7.94ms p95, cold start unencrypted 155.88ms p95). 1 PASS post-fix F (curator 50K decay 206ms p95 vs 30s target). 1 ajuste SLO encrypted (1412ms vs nuevo target 1500ms). **Caveat Phase-9**: los benchmarks miden los caminos felices con embedder mockeado; no detectan que en produccion el embedder NO se carga (B-MCP-3). |
 | **SLO encrypted** | Cold start `<1500ms` (revisado desde `<400ms` previo, mantiene Argon2id OWASP 2024 — 64 MiB / 3 iter / 4 parallel). Decision E del architect-final-review. |
-| **Vulns npm audit** | 1 cerrada (`uuid` bumpeado a 14.x). **2 highs upstream** heredadas de `fastembed@^2.0.0` → `tar@6.x` (path-traversal/symlink poisoning en extraccion de tarball). Phase-7 sub-fase 5 (2026-04-28) **investigo y documento como wontfix** tras descartar 4 alternativas: bump (fastembed@2.1 sigue con tar@6), override (tar@7 sin default ESM rompe import), swap embedder (v0.5-class), shim custom (regla "no security custom"). Ver ADR-004 en `docs/12-lineamientos-arquitectura.md §1.5.4` + §6.11. Vector real corregido: download desde GCS de Qdrant (no HuggingFace). SonarQube **sigue en 0 vulnerabilities** sobre nuestro codigo. **Phase-9 hallazgo**: el embedder fastembed nunca se carga en produccion (B-MCP-3), asi que el path vulnerable de tar tampoco se ejerce — pero esto NO es mitigacion, es bug. |
-| **Paquete npm** | **Canal beta**: `@netzi/recall@0.1.2-beta.3` **PUBLICADO** (2026-05-01 noche) — `npm view @netzi/recall dist-tags` retorna `{latest: '0.1.1', beta: '0.1.2-beta.3'}`. Tarball: 6.6 MB, 16 archivos. **Canal latest**: `@netzi/recall@0.1.1` sigue deprecada (latest no se promueve hasta cerrar B-MCP-7 + cortar `0.1.2` stable). `v0.1.2-beta.0` superseded por beta.3 en mismo canal. `v0.1.0`/`v0.1.1` deprecadas historicamente. `publishConfig.access=public`. Bins `recall` y `recall-server`. |
+| **Vulns npm audit** | 1 cerrada (`uuid` bumpeado a 14.x). **2 highs upstream** heredadas de `fastembed@^2.0.0` → `tar@6.x` (path-traversal/symlink poisoning en extraccion de tarball). Phase-7 sub-fase 5 (2026-04-28) **investigo y documento como wontfix** tras descartar 4 alternativas: bump (fastembed@2.1 sigue con tar@6), override (tar@7 sin default ESM rompe import), swap embedder (v0.5-class), shim custom (regla "no security custom"). Ver ADR-004 en `docs/12-lineamientos-arquitectura.md §1.5.4` + §6.11. Vector real corregido: download desde GCS de Qdrant (no HuggingFace). SonarQube **sigue en 0 vulnerabilities** sobre nuestro codigo. **Phase-13 hallazgo**: con B-MCP-7 cerrado el embedder ya SE carga (worker tolera cold-start), asi que el path tar SI se ejerce en produccion — el wontfix sigue siendo correcto (path tar no es accesible al input del usuario, solo a tarballs descargados de GCS) pero el caveat "el path no se ejerce" de Phase-9 ya no aplica. |
+| **Paquete npm** | **Canal beta**: `@netzi/recall@0.1.2-beta.3` PUBLICADO (2026-05-01 noche) — `npm view @netzi/recall dist-tags` retorna `{latest: '0.1.1', beta: '0.1.2-beta.3'}`. Tarball: 6.6 MB, 16 archivos. **Canal latest**: `@netzi/recall@0.1.1` sigue deprecada (latest no se promueve hasta cortar `0.1.2` stable). `0.1.2-beta.4` (con B-MCP-7 fix) **PENDIENTE de cortar release branch + publish**. `v0.1.2-beta.0` superseded por beta.3 en mismo canal. `v0.1.0`/`v0.1.1` deprecadas historicamente. `publishConfig.access=public`. Bins `recall` y `recall-server`. |
 | **Licencia** | MIT (`code/LICENSE`). |
-| **Estado del release** | **PUBLICADO + smoke validado parcial.** `@netzi/recall@0.1.2-beta.3` en npm beta channel. Tag `v0.1.2-beta.3` → commit `9429bbd` (= main HEAD, incluye doc fixes hotfix #23). GitHub pre-release publicado. Smoke post-publish con DB real del dogfood: **B-MCP-2 ✅** (mem.health con valores reales), **B-MCP-3 wiring ✅** (worker arranca, antes nunca corria), **B-MCP-4 ✅** (migration 008 aplicada, schema_version=8, content backfilled), **BM25 lexical ✅** (mem.recall con query exacta retorna hits). **B-MCP-7 (nuevo, high) ❌**: worker burnea 5 retries durante cold-start de fastembed (~4.3s init), 32/64 items quedaron en attempts=5 permanent failure. Semantic recall sigue cayendo a `fallback_reason: "embedder_unavailable"` hasta que B-MCP-7 cierre. |
-| **Issues GitHub abiertos** | **1** — [#24 B-MCP-7](https://github.com/NetziTech/recall/issues/24) (high) descubierto en smoke post-publish. Los 4 originales cerrados via PRs #17/#18/#19/#20. |
-| **Memoria propia** | **POBLADA por dogfood + ahora con migration 008 aplicada** — `<repo>/.recall/recall.db` tiene 64 entries (27 decisions + 23 learnings + 11 entities + 0 tasks + 3 turns), `schema_version=8`, modo `private`. **embedding_queue: 32 items en attempts=0 + 32 items en attempts=5 (permanent failure)** post-smoke por B-MCP-7. Recovery requiere reset del attempts counter (Option C en issue #24) + cerrar B-MCP-7. **Caveat**: durante el smoke hice `UPDATE embedding_queue SET attempts=0` por SQL directo violando regla CLAUDE.md "NUNCA modificar la DB directamente"; debi haber implementado un comando CLI primero. Documentado en §6.17 como flow lesson. |
-| **Repositorio GitHub** | https://github.com/NetziTech/recall — PUBLICO. `main` PR-only desde develop, CI required, enforce_admins. `develop` default branch (CI required, enforce_admins, push directo bloqueado por strict status check — la HANDOFF Phase-10 decia "permitido a maintainers" pero empiricamente NO se permite sin CI verde primero, descubierto en Phase-12 §6.17). Forks habilitados. Squash-only merges. |
-| **Proximo paso** | **v0.1.2-beta.4: cerrar B-MCP-7** ([#24](https://github.com/NetziTech/recall/issues/24)). Fix recomendado (Option A del issue): differenciar `EmbedderUnavailableError` (transport-level, no incrementar attempts del item, back-off del batch entero con exponential delay) vs `EmbedFailedError` (per-item, mantener el counter). Plus: agregar comando `recall reset-queue` (Option C del issue) para usuarios afectados. Despues, dogfood real validando que el worker dren la cola, y promover `release/0.1.2` stable + mover `latest` desde 0.1.1 → 0.1.2. |
-| **Workflow Claude (settings.json hooks)** | **PENDIENTE de configurar** post-Phase-12. Razon: cometi 2 violaciones de flow en Phase-12 (commit a main por error, manual SQL UPDATE en DB del dogfood) que la branch protection ataja parcialmente pero el harness podria prevenir antes. Opciones discutidas: (A) `.claude/settings.json` per-repo con `PreToolUse` hooks (recomendado), (B) `~/.claude/settings.json` per-user, (C) ambos. Reglas propuestas: pre-`Bash git commit` aborta si current branch es main/develop; pre-`Bash git push origin main\|develop` aborta siempre; pre-`Bash git commit` con cambios en `code/src/` corre `npm run typecheck` minimo. Skill `update-config` lista para invocar. |
+| **Estado del release** | **`develop` listo para cortar `release/0.1.2-beta.4`.** B-MCP-7 fix mergeado a develop (`5903fb4`). Pendiente: bump version + release notes + PR a main + tag + npm publish `--tag beta` + smoke contra DB del dogfood validando que el worker drena la cola post-fix (typed error union, exponential back-off, `recall reset-queue` command para recovery). El `0.1.2-beta.3` sigue en npm beta channel hasta que beta.4 lo reemplace. |
+| **Issues GitHub abiertos** | **0** — [#24 B-MCP-7](https://github.com/NetziTech/recall/issues/24) cerrado via PR [#27](https://github.com/NetziTech/recall/pull/27). Los 4 originales (B-MCP-2/3/4/5) cerrados en Phase-11 via PRs #17/#18/#19/#20. |
+| **Memoria propia** | **POBLADA por dogfood, queue PENDIENTE de drenar tras smoke de beta.4** — `<repo>/.recall/recall.db` tiene 64 entries (27 decisions + 23 learnings + 11 entities + 0 tasks + 3 turns), `schema_version=8`, modo `private`. **embedding_queue:** 32 items en attempts=0 + 32 items en attempts=5 (perma-fail por B-MCP-7 antes del fix). El fix de Phase-13 incluye `recall reset-queue` que clarea attempts>=5 → al smoke post-publish de beta.4: correr `recall reset-queue` primero, despues spawn `recall-server` y verificar que el worker drena los 64 (el fix tolera el cold-start sin quemar attempts). **Lecciona Phase-12 ya codificada en hooks (PR #26)**: pre-`Bash git commit` en main/develop aborta; pre-`Bash git commit` con cambios en `code/src/` corre `npm run typecheck`. Manual `UPDATE embedding_queue` SQL directo SIGUE siendo violacion CLAUDE.md, ahora cubierto por el comando CLI nuevo. |
+| **Repositorio GitHub** | https://github.com/NetziTech/recall — PUBLICO. `main` PR-only desde develop, CI required, enforce_admins. `develop` default branch (CI required, enforce_admins, push directo bloqueado por strict status check). Forks habilitados. Squash-only merges. **Phase-13: pre-commit hooks per-repo en `.claude/settings.json`** (PR #26) — bloquean `git commit` en main/develop antes de que branch protection rechace el push. |
+| **Proximo paso** | **Cortar `release/0.1.2-beta.4`** desde develop (`5903fb4`): bump `code/package.json` + `code/sonar-project.properties` + nuevo `docs/RELEASE-NOTES-v0.1.2-beta.4.md` + actualizar README.md banner + SECURITY.md tabla. PR `release/0.1.2-beta.4` → main, CI verde, squash-merge, tag `v0.1.2-beta.4`, GitHub pre-release, `npm publish --tag beta` (usuario via `--auth-type=web`). Despues: smoke contra DB del dogfood (con `recall reset-queue` primero) validando worker drena cola + semantic recall recupera con queries paraphrased. Si pasa: cortar `release/0.1.2` stable, `npm dist-tag add @netzi/recall@0.1.2 latest`, deprecar `0.1.0`/`0.1.1`. |
+| **Workflow Claude (settings.json hooks)** | **CONFIGURADO** via PR [#26](https://github.com/NetziTech/recall/pull/26) (mergeado `94f0fcf`). 3 hooks `PreToolUse > Bash` per-repo en `.claude/settings.json` + scripts en `.claude/hooks/`: (1) `block-protected-commit.sh` aborta `git commit` en main/develop con exit 2; (2) `block-protected-push.sh` aborta push desde main/develop o cuyo destino sea main/develop (cubre `origin main`, `HEAD:main`, `:main`, push implicito); (3) `typecheck-on-commit.sh` corre `npm run typecheck` en `code/` cuando hay cambios staged en `code/src/` (cero overhead en commits docs-only). Filtros `if: "Bash(git commit*)"`/`Bash(git push*)` evitan spawn para Bash que no sea git. UserPromptSubmit hook anti-worktree de CLAUDE.md regla #1 preservado intacto. |
 
 ---
 
@@ -1853,6 +1853,119 @@ Sin reportes formales nuevos (smoke + bugfix incremental, mismo patron que Phase
 
 ---
 
+## 6.18 Phase-13 — Cierre de B-MCP-7 + workflow Claude hooks + SonarQube tooling
+
+**Cierre:** 2026-05-02. Phase-13 fue **el cycle de cierre del backlog post-beta.3 antes de cortar beta.4**. Tres entregas concurrentes:
+1. **PR [#26](https://github.com/NetziTech/recall/pull/26)** — Workflow Claude pre-commit hooks (D-1210 de Phase-12 cerrada).
+2. **PR [#27](https://github.com/NetziTech/recall/pull/27)** — B-MCP-7 fix (typed error union + worker back-off + `recall reset-queue` command).
+3. **Tooling SonarQube** — recovery del admin password, rotacion de tokens, persistencia local del User Token para queries API directas (cierra el gap de las sesiones previas que generaban tokens pero no los persistian, agotando la cuota de tokens en SonarQube).
+
+### Decisiones humanas
+
+| # | Decision | Razon |
+|---|---|---|
+| Q1 | PR #26 (claude-hooks) cortado del PR #27 (B-MCP-7) — no consolidar | El setup de hooks es un cambio de configuracion del proyecto que afecta TODA sesion futura; el B-MCP-7 fix es codigo de producto. Mezclarlos forzaria revision unica de dos cambios ortogonales. |
+| Q2 | B-MCP-7 fix usa Option A (typed error union) + Option C (`recall reset-queue`); no Option B (warmup command) | Option A es la fix arquitectonica permanente; Option C es recovery para usuarios afectados por el bug pre-fix. Option B (`recall warmup`) es band-aid sin valor a largo plazo. |
+| Q3 | SonarQube admin password recuperado via UPDATE directo a la DB postgres | El procedure documentado por SonarSource. Alternativas (regenerar via UI nueva instancia, recuperar via email, etc.) no aplican porque la UI estaba bloqueada y el server no expone email reset. |
+| Q4 | Token de SonarQube para CI corregido a Project Analysis Token (no Global) | Scoping correcto: el token solo debe poder analizar el proyecto `recall`, no cualquier proyecto del SonarQube. |
+| Q5 | User Token de SonarQube persistido en `~/.netzi-secrets/sonar.env` (0600) + memoria reference | Sesiones anteriores generaban tokens cada vez sin persistir, agotando el limite de SonarQube y dejando tokens orfanos. El archivo local resuelve el problema; la memoria apunta al archivo. |
+
+### Sub-fases en orden cronologico
+
+| # | Sub-fase | Owner | Resultado |
+|---|---|---|---|
+| 1 | PR [#26](https://github.com/NetziTech/recall/pull/26) `chore/claude-hooks-setup` → develop | orquestador | CI verde, squash-merged como `94f0fcf`. 3 hooks `PreToolUse > Bash` en `.claude/settings.json` + 3 scripts en `.claude/hooks/` (block-protected-commit, block-protected-push, typecheck-on-commit) con filtros `if: "Bash(git commit*)"`/`Bash(git push*)`. Pipe-tested 32 casos + end-to-end demonstrado bloqueando `git push file:///nonexistent main`. |
+| 2 | PR [#27](https://github.com/NetziTech/recall/pull/27) `feat/b-mcp-7-embedder-cold-start` → develop, primer push | orquestador | CI **FAIL** en SonarQube quality gate. 4 violations nuevas: 1 critical S3776 (`drainBatch` cognitive complexity 17 > 15) + 3 minor S7735 (negated conditions en `cli-facades`, `embed-failed-error`, `embedder-unavailable-error`). Coverage on new code 100%, overall 96.4% — todo OK; el bloqueador era code smells. |
+| 3 | Recovery del admin password de SonarQube (sin acceso a la UI para diagnosticar el quality gate) | orquestador + usuario | Phase 1 (read-only): SSH a `opc@129.146.0.170`, `docker ps` confirma `sonarqube` (community 26.4) + `sonarqube-db` (postgres:15-alpine). DB query confirma usuario `admin` local. Phase 2 (UPDATE): generar BCRYPT hash fresco con `htpasswd -bnBC 12 ""` (el hash documentado por SonarSource para `admin/admin` NO valida en SQ 26.x), aplicar via heredoc + `docker cp` para evitar el bug de multi-layer escaping (bash → ssh → docker → psql se come el prefix `$2a$12$`). Restart SQ container. Login con admin / nuevo password. |
+| 4 | Diagnostico exacto del quality gate via API (con User token) | orquestador | `GET /api/qualitygates/project_status?projectKey=recall` → 14 conditions, 12 OK + 2 ERROR (`new_critical_violations=1`, `new_violations=4`). `GET /api/issues/search?inNewCodePeriod=true` lista las 4 violations especificas con archivo + linea + regla. |
+| 5 | Refactor + push correctivo en PR #27 | orquestador | Extract method en `drainBatch` (8 metodos privados nuevos: `dequeueItems`, `hydrateProjections`, `processItem`, `markPermanentFailure`, `ackPrunedItem`, `embedAndStore`, `recordEmbedFailure`, `markBatchUnavailable`) + flip de las 3 ternarias S7735. CI verde, quality gate OK (0 violations en new code), squash-merged como `5903fb4`. |
+| 6 | Cleanup tokens SonarQube + rotacion del CI token | orquestador | Crear `ci-github-actions-recall` (Project Analysis Token, scoped a `recall`, expira 2026-08-02) via API; actualizar GitHub Secret `SONAR_TOKEN` via `gh secret set`. Revocar `recall-ci-2026-04-28` + `recall-ci-global-2026-04-28` + `mcp-memoria-setup` (3 tokens obsoletos). Persistir User Token `claude-debug` en `~/.netzi-secrets/sonar.env` + memoria reference. |
+
+### Validacion final
+
+- 5/5 EXIT=0 locales (typecheck, lint, validate-modules, tests **2553 passing** en 213 archivos, build).
+- SonarQube quality gate **OK** (14/14 conditions): coverage new 99.8% / overall 96.4%, 0 bugs, 0 vulns, 0 violations new, ratings A.
+- 0 issues GitHub abiertos.
+- 0 PRs abiertos.
+
+### Lecciones durables (codificadas en config + memoria)
+
+1. **El BCRYPT hash documentado por SonarSource para `admin/admin` (`$2a$12$uCkkXmhW...`) NO funciona en SonarQube Community 26.x.** Login silenciosamente rechaza. Fix: generar hash fresco con `htpasswd -bnBC 12 "" admin | tr -d ':\n' | sed 's/^\$2y/$2a/'` y validar (1) length 60, (2) prefix `$2a$12$` ANTES de aplicar el UPDATE. Memoria: `reference_sonarqube_admin_password_reset.md`.
+
+2. **Multi-layer shell escaping (bash → ssh → docker → psql) silenciosamente come `$N` references.** Aplicar el hash inline interpoldo dentro de un comando ssh truncó el prefix `$2a$12$` (variables `$2`, `$a`, `$12` se expandieron a vacio). Fix: pasar el SQL via stdin → `cat > file` → `docker cp` → `psql -f file`. Memoria reference incluye el patron seguro.
+
+3. **SonarQube quality gates pueden fallar por code smells aun con coverage 100% en new code.** El primer push de PR #27 cumplia todas las metricas de coverage pero las conditions `new_critical_violations` y `new_violations` lo bloqueaban por 4 issues de Sonar way (S3776 + 3x S7735). Lecciona: el quality gate no es solo coverage; el conjunto completo (smells + duplications + ratings + violations) debe pasar.
+
+4. **Cognitive complexity S3776 es facil de tropezar al agregar discriminacion de errores tipados.** El `drainBatch` original tenia complexity ~10; agregar el branch `if (cause instanceof EmbedderUnavailableError)` lo subio a 17. Fix: extract method al primer signo (8 metodos privados pequenos en lugar de un metodo grande con 4-5 niveles de nesting). El fix tambien mejora testability (cada metodo es facil de aislar).
+
+5. **S7735 "Unexpected negated condition" es trivial de evitar:** preferir `if (positive) { primary } else { fallback }` sobre `if (!positive) { fallback } else { primary }`. Para ternarias / spreads condicionales: `...(x === null ? {} : { y })` en lugar de `...(x !== null ? { y } : {})`. Las 3 violations del PR fueron ternarias con spread; la flip preserva la semantica exacta.
+
+6. **Los SonarQube tokens deben persistirse explicitamente entre sesiones de Claude.** La sesion anterior creo varios tokens sin persistirlos (cuando vence o se rota el token actual no hay forma de recuperar el valor original — SonarQube los hashea one-way en `user_tokens.token_hash`). Fix: User Token vivo en `~/.netzi-secrets/sonar.env` (0600); reference memoria apunta al path. CI usa Project Analysis Token rotacionado en `gh secret`.
+
+7. **La autorizacion del harness para acciones en prod requiere frases especificas.** Decir "ok" o "si" no basta para que pase un `ssh ... 'docker exec ... psql ... UPDATE ...'`. Hay que decir literalmente que tipo de comando se autoriza. Phase-13 lo aprendio en 4 iteraciones de denegacion antes de obtener la autorizacion correcta.
+
+8. **GitHub Actions Secret values son irrecuperables una vez seteados.** El proyecto rotaba SONAR_TOKEN sin guardar el valor anterior; cuando uno necesita "refrescar" el GitHub Secret hay que regenerarlo en SonarQube primero. Memoria reference incluye el step-by-step de rotacion.
+
+### Estado del repo post-Phase-13
+
+| Item | Valor |
+|---|---|
+| **HEAD de `main`** | `9429bbd` (sin cambios desde Phase-12; `release/0.1.2-beta.4` aun no cortada) |
+| **HEAD de `develop`** | `5903fb4` (incluye PRs #25 docs Phase-12 + #26 hooks + #27 B-MCP-7 fix) |
+| **Tag mas reciente** | `v0.1.2-beta.3` → `9429bbd` (sin cambios) |
+| **GitHub release mas reciente** | https://github.com/NetziTech/recall/releases/tag/v0.1.2-beta.3 (sin cambios) |
+| **npm dist-tags** | `{ latest: '0.1.1', beta: '0.1.2-beta.3' }` (sin cambios; `beta.4` pendiente de cortar release branch) |
+| **Issues abiertos** | **0** |
+| **PRs abiertos** | **0** |
+| **Tests** | 2553 passing en 213 archivos |
+| **Coverage SonarQube** | new 99.8% / overall 96.4% |
+| **Tokens SonarQube activos** | 3: `ci-github-actions` (Finqora), `ci-github-actions-recall` (CI de recall, expira 2026-08-02), `claude-debug` (User, expira 2026-05-31) |
+
+### Archivos tocados en Phase-13
+
+| Archivo | Cambio | PR |
+|---|---|---|
+| `.claude/settings.json` | +PreToolUse > Bash (3 hooks) preservando UserPromptSubmit | #26 |
+| `.claude/hooks/block-protected-commit.sh` | NEW (27 LOC) | #26 |
+| `.claude/hooks/block-protected-push.sh` | NEW (40 LOC) | #26 |
+| `.claude/hooks/typecheck-on-commit.sh` | NEW (34 LOC) | #26 |
+| `code/src/modules/retrieval/domain/errors/embedder-unavailable-error.ts` | NEW | #27 |
+| `code/src/modules/retrieval/domain/errors/embed-failed-error.ts` | NEW | #27 |
+| `code/src/modules/retrieval/domain/services/embedder.ts` | docstring updated (typed errors documented) | #27 |
+| `code/src/modules/retrieval/application/use-cases/embed-and-persist.use-case.ts` | extract-method refactor + unavailable branch + DrainAccumulator + EMPTY_RESULT | #27 |
+| `code/src/modules/retrieval/application/use-cases/reset-embedding-queue.use-case.ts` | NEW | #27 |
+| `code/src/modules/retrieval/application/ports/out/embedding-queue-repository.port.ts` | + `resetPermanentFailures` method | #27 |
+| `code/src/modules/retrieval/infrastructure/embedder/raw-embedder-adapter.ts` | + `translateError` (shared `EmbedderError` → domain typed errors) | #27 |
+| `code/src/modules/retrieval/infrastructure/persistence/sqlite-embedding-queue-repository.ts` | + `resetPermanentFailures` impl + SQL constant | #27 |
+| `code/src/modules/retrieval/infrastructure/worker/async-embedding-worker.ts` | + back-off logic + `runDrain` extract-method refactor | #27 |
+| `code/src/modules/cli/application/use-cases/handlers/embedding-queue-handlers.ts` | NEW (`ResetQueueCommandHandler`) | #27 |
+| `code/src/modules/cli/application/ports/out/embedding-queue-facade.port.ts` | NEW | #27 |
+| `code/src/modules/cli/application/dtos/cli-invocation.dto.ts` | + `CliResetQueueInvocation` variant | #27 |
+| `code/src/modules/cli/domain/value-objects/command-name.ts` | + `"reset-queue"` literal | #27 |
+| `code/src/modules/cli/infrastructure/parser/commander-cli-parser.ts` | + `reset-queue` command registration | #27 |
+| `code/src/composition/facades/cli-facades.ts` | + `CliResetQueueFacadeAdapter` | #27 |
+| `code/src/composition/wiring/retrieval-wiring.ts` | + `resetEmbeddingQueue` use case | #27 |
+| `code/src/composition/wiring/cli-wiring.ts` | + `ResetQueueCommandHandler` registration | #27 |
+| `code/src/composition/container.ts` | + `resetQueue` facade in CLI bag | #27 |
+| `code/tests/integration/O-embedder-cold-start.test.ts` | NEW (2 tests, B-MCP-7 regression) | #27 |
+| `code/tests/integration/_helpers/stub-embedder.ts` | + `nextErrors[]` queue for cold-start sim | #27 |
+| `code/tests/unit/retrieval/application/embed-and-persist.use-case.test.ts` | +6 tests (B-MCP-7 unavailable branches) | #27 |
+| `code/tests/unit/retrieval/application/reset-embedding-queue.use-case.test.ts` | NEW (4 tests) | #27 |
+| `code/tests/unit/retrieval/infrastructure/raw-embedder-adapter.test.ts` | +6 tests (typed error translation matrix) | #27 |
+| `code/tests/unit/retrieval/infrastructure/async-embedding-worker.test.ts` | +6 tests (back-off behaviour) | #27 |
+| `code/tests/unit/retrieval/infrastructure/sqlite-embedding-queue-repository.test.ts` | +3 tests (resetPermanentFailures) | #27 |
+| `code/tests/unit/cli/application/handlers/embedding-queue-handlers.test.ts` | NEW (4 tests) | #27 |
+| `code/tests/unit/cli/infrastructure/parser/commander-cli-parser.test.ts` | +3 tests (`reset-queue` parser) | #27 |
+| `code/tests/unit/cli/domain/value-objects/command-name.test.ts` | + `"reset-queue"` in catalog | #27 |
+| `code/tests/fixtures/cli-fixtures.ts` | + `StubResetQueueFacade` | #27 |
+| `HANDOFF.md` | §0 + nueva §6.18 (este commit) | nuevo PR Phase-13 |
+
+### Siguiente accion concreta
+
+Cortar `release/0.1.2-beta.4` desde develop (`5903fb4`), bump versions (`code/package.json` + `code/sonar-project.properties` → `0.1.2-beta.4`), nuevo `docs/RELEASE-NOTES-v0.1.2-beta.4.md`, actualizar README banner + SECURITY tabla, PR a main, CI verde, squash-merge, tag, GitHub pre-release, npm publish `--tag beta`, smoke contra DB del dogfood (con `recall reset-queue` primero) validando que el worker drena la cola post-fix.
+
+---
+
 ## 7. Como retomar el trabajo
 
 ### Si soy yo mismo (otra sesion de Claude Code)
@@ -2314,5 +2427,5 @@ sistema de modulos absorben la evolucion sin cambios estructurales.
 
 ---
 
-_Ultima actualizacion: 2026-05-01 noche (cierre Phase-12 — `@netzi/recall@0.1.2-beta.3` PUBLICADO en npm beta channel; smoke post-publish valido B-MCP-2/3/4/5 fixes contra DB real del dogfood pero descubrio B-MCP-7 (issue #24) — worker burnea retries durante cold-start de fastembed. Proximo: cerrar B-MCP-7 en `v0.1.2-beta.4`, despues promover a `0.1.2` stable. Workflow Claude pre-commit hooks PENDIENTE de configurar via skill update-config.)_
+_Ultima actualizacion: 2026-05-02 (cierre Phase-13 — B-MCP-7 cerrado via PR #27 con typed error union (`EmbedderUnavailableError` vs `EmbedFailedError`) + worker exponential back-off + `recall reset-queue` CLI command. Workflow Claude pre-commit hooks shipped via PR #26. SonarQube quality gate verde (0 violations en new code, coverage new 99.8% / overall 96.4%). Token CI rotacionado a Project Analysis Token; User Token persistido en `~/.netzi-secrets/sonar.env` para queries API directas. 0 issues abiertos. Proximo: cortar `release/0.1.2-beta.4` con bump versions + release notes + smoke post-publish.)_
 _Mantenedor: equipo Netzi Tech_


### PR DESCRIPTION
## Summary

Closes the documentation gap left after Phase-13 (PRs #26 and #27) merged to develop without updating HANDOFF.md.

Updates **§0** (10 stale rows: Fecha del handoff, Fase actual, Lineas de codigo, Lineas de docs, SonarQube, Tests 2519→2553, Vulns npm audit, Paquete npm, Estado del release, Issues abiertos 1→0, Memoria propia, Repositorio GitHub, Proximo paso, Workflow Claude hooks PENDIENTE→CONFIGURADO) and adds new **§6.18 Phase-13** documenting the cycle.

## Phase-13 highlights

| | Entrega |
|---|---|
| **PR [#26](https://github.com/NetziTech/recall/pull/26)** | claude-hooks-setup — 3 PreToolUse Bash hooks per-repo (block commit on main/develop, block push to main/develop, typecheck on commit when code/src/ touched). Mergeado `94f0fcf`. |
| **PR [#27](https://github.com/NetziTech/recall/pull/27)** | B-MCP-7 fix — typed error union (`EmbedderUnavailableError` vs `EmbedFailedError`) + worker exponential back-off + `recall reset-queue` CLI command. +31 archivos / +1929 LOC. Tests +34. Mergeado `5903fb4`. |
| **SonarQube tooling** | Admin password recovery via DB UPDATE (SonarSource-documented hash fails on SQ Community 26.x), CI token rotated to Project Analysis Token, User Token persistido en `~/.netzi-secrets/sonar.env`. |

## 8 durable lessons recorded in §6.18

1. SonarSource-documented BCRYPT hash for "admin" does NOT verify on SQ 26.x — generate fresh with `htpasswd`.
2. Multi-layer shell escaping (bash → ssh → docker → psql) silently eats `$N` references.
3. SonarQube quality gates fail on code smells even with 100% coverage on new code.
4. Cognitive complexity S3776 trivially exceeded when adding typed-error discrimination — extract method early.
5. S7735 negated conditions easy to flip to positive.
6. Persist SonarQube tokens between sessions; never regenerate per-session.
7. Harness needs specific authorization phrases for production actions.
8. GitHub Actions secret values are irrecoverable post-set; rotate from source.

## Test plan

- [x] No code changes; doc-only PR.
- [x] CI runs lint/typecheck/tests/build/SonarQube same as code PRs.
- [x] §6.18 references match the actual PR numbers + commit SHAs (5903fb4, 94f0fcf, 9429bbd).

## Next step (after this merge)

Cortar `release/0.1.2-beta.4` desde develop. The §6.18 closing section ("Siguiente accion concreta") spells out the exact bumps + release notes + README/SECURITY updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)