### PR TITLE
fix(bootstrap): read serverInfo.version from package.json at runtime (sync drift carryover)

### DIFF
--- a/code/src/bootstrap/composition-root.ts
+++ b/code/src/bootstrap/composition-root.ts
@@ -92,75 +92,103 @@ import { PinoLogger } from "../shared/infrastructure/logger/pino-logger.ts";
  * the failure surface is `migrationDirectoryInvalid(<path>)` rather
  * than a silently-picked stale folder.
  */
-function resolveDefaultMigrationsDir(): string {
-  // 1) Env override.
-  const fromEnv = process.env["RECALL_MIGRATIONS_DIR"];
-  if (fromEnv !== undefined && fromEnv.length > 0) {
-    return path.resolve(fromEnv);
-  }
+/**
+ * Discriminator for the two anchor sources `collectFsCandidates`
+ * walks. Resolvers can return different candidate paths per kind —
+ * the migrations resolver, for instance, intentionally skips the
+ * `<here>/../migrations` candidate under `importMeta` because that
+ * path resolves to `code/src/migrations/` which never exists.
+ */
+type AnchorKind = "argv" | "importMeta";
 
+/**
+ * Walks both filesystem anchors the bootstrap can use to find
+ * sibling files (`migrations/`, `package.json`, future helpers...):
+ *
+ *   1. The `argv[1]` entrypoint, with `fs.realpathSync` to follow
+ *      npm-global symlinks (see B-CLI-5 for the failure mode this
+ *      avoids). Both the realpath-derived AND the literal-argv
+ *      anchors are tried in case `realpath` is unavailable.
+ *   2. `import.meta.url`, useful for unit tests + tsx-imported
+ *      bootstrap paths where `argv[1]` does not point at this file.
+ *
+ * For every anchor, the caller supplies a `builder(anchor, kind)`
+ * that returns the candidate paths it wants to try (already in
+ * priority order). Returned paths are de-duplicated globally so the
+ * common dev case (realpath = literal) does not double-stat each
+ * candidate.
+ *
+ * Extracted from {@link resolveDefaultMigrationsDir} when
+ * {@link resolvePackageVersion} grew the same anchor-walking
+ * boilerplate; see Sonar S4144 and S3776 (PR #37 round 2).
+ */
+function collectFsCandidates(
+  builder: (anchor: string, kind: AnchorKind) => readonly string[],
+): readonly string[] {
   const candidates: string[] = [];
-  // De-duplicates the candidate list when realpath returns a path
-  // identical to the literal-argv fallback (the common case in
-  // development, where the bin is not a symlink). Ensures
-  // `fs.statSync` is called at most once per real directory.
   const seen = new Set<string>();
-  const pushCandidate = (candidate: string): void => {
+  const push = (candidate: string): void => {
     if (seen.has(candidate)) return;
     seen.add(candidate);
     candidates.push(candidate);
   };
 
-  const pushAnchor = (entryDir: string): void => {
-    pushCandidate(path.join(entryDir, "migrations"));
-    pushCandidate(path.resolve(entryDir, "..", "migrations"));
-    pushCandidate(path.resolve(entryDir, "..", "..", "migrations"));
-  };
-
-  // 2) Entrypoint-relative — the path Node was launched with.
   const argvEntry = process.argv[1];
   if (argvEntry !== undefined && argvEntry.length > 0) {
     const literalEntry = path.resolve(argvEntry);
-    // Resolve symlinks first so npm global installs (which place a
-    // symlink at `<prefix>/bin/recall` pointing to the real bundle
-    // under `<prefix>/lib/node_modules/.../dist/cli.js`) anchor on
-    // the real bundle directory rather than `<prefix>/bin/`.
     let realEntry: string | null = null;
     try {
       realEntry = fs.realpathSync(literalEntry);
     } catch {
-      // The argv path does not exist or is not accessible. The
-      // bootstrap caller will see the same failure when it tries to
-      // load the bundle, so swallowing here is safe.
       realEntry = null;
     }
     if (realEntry !== null) {
-      pushAnchor(path.dirname(realEntry));
+      for (const c of builder(path.dirname(realEntry), "argv")) push(c);
     }
-    // Defensive fallback: even when `realpath` succeeded above, the
-    // literal-argv anchor is still considered so a hand-crafted
-    // launcher (which does not symlink) keeps working.
-    pushAnchor(path.dirname(literalEntry));
+    for (const c of builder(path.dirname(literalEntry), "argv")) push(c);
   }
 
-  // 3) `import.meta.url`-relative — useful when the bootstrap is
-  //    imported directly (unit tests) and `argv[1]` does not point at
-  //    this module.
   try {
     const here = path.dirname(fileURLToPath(import.meta.url));
-    // Sibling layout: post-build, the bundled `cli.js` lives at
-    // `<paquete>/dist/cli.js`, and the `onSuccess` tsup hook places
-    // migrations at `<paquete>/dist/migrations/` — which is `here`
-    // resolved alongside. This candidate was MISSING in the original
-    // resolver (B-CLI-5).
-    pushCandidate(path.resolve(here, "migrations"));
-    // Dev layout: `code/src/bootstrap/` → `code/migrations/` (two
-    // levels up).
-    pushCandidate(path.resolve(here, "..", "..", "migrations"));
+    for (const c of builder(here, "importMeta")) push(c);
   } catch {
-    // `fileURLToPath` can throw on exotic schemes. Ignored — the
-    // argv-derived candidates are the canonical source.
+    /* `fileURLToPath` can throw on exotic schemes — argv anchor is canonical anyway */
   }
+
+  return candidates;
+}
+
+function resolveDefaultMigrationsDir(): string {
+  // Env override short-circuits both anchor walks.
+  const fromEnv = process.env["RECALL_MIGRATIONS_DIR"];
+  if (fromEnv !== undefined && fromEnv.length > 0) {
+    return path.resolve(fromEnv);
+  }
+
+  const candidates = collectFsCandidates((anchor, kind) => {
+    if (kind === "argv") {
+      // Three candidates per binary anchor:
+      //   a. `<entry>/migrations`        — tsup `onSuccess` ships
+      //      migrations alongside the bundle on release.
+      //   b. `<entry>/../migrations`     — dev path: `code/src/
+      //      bootstrap/` → `code/migrations/`.
+      //   c. `<entry>/../../migrations`  — legacy / nested dist
+      //      trees; preserved as the last resort to keep the E2E
+      //      harness's staging layout valid.
+      return [
+        path.join(anchor, "migrations"),
+        path.resolve(anchor, "..", "migrations"),
+        path.resolve(anchor, "..", "..", "migrations"),
+      ];
+    }
+    // `importMeta`: only two candidates — the `<here>/../migrations`
+    // path would resolve to `code/src/migrations/` which never exists
+    // in any supported layout.
+    return [
+      path.resolve(anchor, "migrations"),
+      path.resolve(anchor, "..", "..", "migrations"),
+    ];
+  });
 
   for (const candidate of candidates) {
     try {
@@ -248,85 +276,57 @@ const UNKNOWN_PACKAGE_VERSION = "0.0.0-unknown";
  * package metadata file.
  */
 export function resolvePackageVersion(): string {
-  const candidates: string[] = [];
-  const seen = new Set<string>();
-  const pushCandidate = (candidate: string): void => {
-    if (seen.has(candidate)) return;
-    seen.add(candidate);
-    candidates.push(candidate);
-  };
-
-  const pushAnchor = (entryDir: string): void => {
+  const candidates = collectFsCandidates((anchor) => [
     // Sibling of dist/ (production npm install layout).
-    pushCandidate(path.resolve(entryDir, "..", "package.json"));
-    // Sibling of src/ (dev / tsx layout — `code/src/bootstrap/` →
-    // `code/package.json`).
-    pushCandidate(path.resolve(entryDir, "..", "..", "package.json"));
-  };
-
-  // 1) Anchored on `argv[1]` (with realpath for npm-global symlinks).
-  const argvEntry = process.argv[1];
-  if (argvEntry !== undefined && argvEntry.length > 0) {
-    const literalEntry = path.resolve(argvEntry);
-    let realEntry: string | null = null;
-    try {
-      realEntry = fs.realpathSync(literalEntry);
-    } catch {
-      realEntry = null;
-    }
-    if (realEntry !== null) pushAnchor(path.dirname(realEntry));
-    pushAnchor(path.dirname(literalEntry));
-  }
-
-  // 2) Anchored on `import.meta.url` (unit tests + tsx-imported
-  // bootstrap paths where `argv[1]` does not point at this module).
-  try {
-    const here = path.dirname(fileURLToPath(import.meta.url));
-    pushAnchor(here);
-  } catch {
-    /* ignore exotic url schemes */
-  }
+    path.resolve(anchor, "..", "package.json"),
+    // Sibling of src/ (dev / tsx layout — `code/src/bootstrap/`
+    // → `code/package.json`).
+    path.resolve(anchor, "..", "..", "package.json"),
+  ]);
 
   for (const candidate of candidates) {
-    let raw: string;
-    try {
-      raw = fs.readFileSync(candidate, "utf8");
-    } catch {
-      continue;
-    }
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      continue;
-    }
-    if (typeof parsed !== "object" || parsed === null) continue;
-    // The first candidate when running under `vitest` is the
-    // vitest binary's own `package.json` (anchored on `argv[1]`).
-    // Without the name guard, the helper would return `1.1.1`
-    // (vitest's version) instead of recall's. Pinning the expected
-    // package name is also a defence against an upstream `node`
-    // launcher that anchors the resolver on something else entirely.
-    const name = (parsed as { readonly name?: unknown }).name;
-    if (name !== EXPECTED_PACKAGE_NAME) continue;
-    const version = (parsed as { readonly version?: unknown }).version;
-    if (typeof version === "string" && version.length > 0) {
-      return version;
-    }
+    const version = readPackageVersionField(candidate);
+    if (version !== null) return version;
   }
-
   return UNKNOWN_PACKAGE_VERSION;
 }
 
 /**
  * The `name` field expected in the bundled `package.json`.
- * {@link resolvePackageVersion} skips any candidate whose `name`
+ * {@link readPackageVersionField} skips any candidate whose `name`
  * does not match this constant — without the guard, the resolver
  * would return the `version` of the first sibling `package.json`
  * it finds, including binaries like `vitest` whose `argv[1]`
  * anchors the search.
  */
 const EXPECTED_PACKAGE_NAME = "@netzi/recall";
+
+/**
+ * Reads `version` from a candidate `package.json`. Returns `null`
+ * if the file is missing, malformed JSON, lacks the right `name`
+ * field, or the version field is absent / empty. Extracted from
+ * {@link resolvePackageVersion} to keep its cognitive complexity
+ * inside the Sonar S3776 limit (PR #37 round 2).
+ */
+function readPackageVersionField(candidate: string): string | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(candidate, "utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const name = (parsed as { readonly name?: unknown }).name;
+  if (name !== EXPECTED_PACKAGE_NAME) return null;
+  const version = (parsed as { readonly version?: unknown }).version;
+  return typeof version === "string" && version.length > 0 ? version : null;
+}
 
 /**
  * Construction options for {@link bootstrapComposition}.

--- a/code/src/bootstrap/composition-root.ts
+++ b/code/src/bootstrap/composition-root.ts
@@ -221,6 +221,114 @@ function tryReadWorkspaceId(workspaceRoot: string): WorkspaceId | null {
 }
 
 /**
+ * Sentinel returned when {@link resolvePackageVersion} cannot locate
+ * or parse the bundled `package.json`. Returning a clearly-fake
+ * version (rather than throwing) lets the bootstrap proceed — the
+ * value surfaces on `initialize.serverInfo.version` so any client
+ * inspecting the handshake immediately sees something is off, while
+ * tools/calls keep working.
+ */
+const UNKNOWN_PACKAGE_VERSION = "0.0.0-unknown";
+
+/**
+ * Reads the package version from the bundled `package.json`.
+ *
+ * The literal that used to live inline at the
+ * `bootstrapComposition.serverInfo.version` callsite drifted out of
+ * sync with `code/package.json` twice (beta.4 and beta.5 releases —
+ * see HANDOFF §6.20). Reading the value at runtime eliminates the
+ * disciplinary requirement to update two files on every bump.
+ *
+ * Resolution mirrors {@link resolveDefaultMigrationsDir}: the
+ * `package.json` file is a sibling of `dist/` in production (post-
+ * tsup install) and a sibling of `src/` in development. Both anchors
+ * are tried in order; if neither yields a parseable JSON with a
+ * `version` string field, the {@link UNKNOWN_PACKAGE_VERSION}
+ * sentinel is returned so the bootstrap never blocks on a missing
+ * package metadata file.
+ */
+export function resolvePackageVersion(): string {
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+  const pushCandidate = (candidate: string): void => {
+    if (seen.has(candidate)) return;
+    seen.add(candidate);
+    candidates.push(candidate);
+  };
+
+  const pushAnchor = (entryDir: string): void => {
+    // Sibling of dist/ (production npm install layout).
+    pushCandidate(path.resolve(entryDir, "..", "package.json"));
+    // Sibling of src/ (dev / tsx layout — `code/src/bootstrap/` →
+    // `code/package.json`).
+    pushCandidate(path.resolve(entryDir, "..", "..", "package.json"));
+  };
+
+  // 1) Anchored on `argv[1]` (with realpath for npm-global symlinks).
+  const argvEntry = process.argv[1];
+  if (argvEntry !== undefined && argvEntry.length > 0) {
+    const literalEntry = path.resolve(argvEntry);
+    let realEntry: string | null = null;
+    try {
+      realEntry = fs.realpathSync(literalEntry);
+    } catch {
+      realEntry = null;
+    }
+    if (realEntry !== null) pushAnchor(path.dirname(realEntry));
+    pushAnchor(path.dirname(literalEntry));
+  }
+
+  // 2) Anchored on `import.meta.url` (unit tests + tsx-imported
+  // bootstrap paths where `argv[1]` does not point at this module).
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    pushAnchor(here);
+  } catch {
+    /* ignore exotic url schemes */
+  }
+
+  for (const candidate of candidates) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(candidate, "utf8");
+    } catch {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    // The first candidate when running under `vitest` is the
+    // vitest binary's own `package.json` (anchored on `argv[1]`).
+    // Without the name guard, the helper would return `1.1.1`
+    // (vitest's version) instead of recall's. Pinning the expected
+    // package name is also a defence against an upstream `node`
+    // launcher that anchors the resolver on something else entirely.
+    const name = (parsed as { readonly name?: unknown }).name;
+    if (name !== EXPECTED_PACKAGE_NAME) continue;
+    const version = (parsed as { readonly version?: unknown }).version;
+    if (typeof version === "string" && version.length > 0) {
+      return version;
+    }
+  }
+
+  return UNKNOWN_PACKAGE_VERSION;
+}
+
+/**
+ * The `name` field expected in the bundled `package.json`.
+ * {@link resolvePackageVersion} skips any candidate whose `name`
+ * does not match this constant — without the guard, the resolver
+ * would return the `version` of the first sibling `package.json`
+ * it finds, including binaries like `vitest` whose `argv[1]`
+ * anchors the search.
+ */
+const EXPECTED_PACKAGE_NAME = "@netzi/recall";
+
+/**
  * Construction options for {@link bootstrapComposition}.
  */
 export interface BootstrapCompositionOptions {
@@ -323,11 +431,10 @@ export async function bootstrapComposition(
   const logDestination: 1 | 2 = options.logDestination ?? 1;
   const serverInfo = options.serverInfo ?? {
     name: "recall",
-    // Kept in lockstep with `code/package.json` `version`. A future
-    // refactor can read this at build time via tsup; the literal is
-    // adequate for now and avoids a runtime require/import of the
-    // package metadata.
-    version: "0.1.2-beta.3",
+    // Read from `package.json` at boot rather than hardcoded — see
+    // {@link resolvePackageVersion} for the rationale and the
+    // failed-discipline incidents this avoids.
+    version: resolvePackageVersion(),
     protocolVersion: "2024-11-05",
   };
 

--- a/code/tests/e2e/B-mcp-server-binary.test.ts
+++ b/code/tests/e2e/B-mcp-server-binary.test.ts
@@ -15,6 +15,10 @@
  *     (`-32601`), unknown tool name.
  */
 
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import {
@@ -25,6 +29,24 @@ import {
   startMcpServer,
   type McpServerSession,
 } from "./_helpers/binary-harness.ts";
+
+/**
+ * Reads `code/package.json#version` so the handshake assertion
+ * below pins to VALUES (not SHAPE). Without this, the previous
+ * `expect(typeof version).toBe("string")` assertion silently
+ * accepted the `0.1.2-beta.3` literal that drifted out of sync
+ * across the beta.4 and beta.5 bumps (HANDOFF §0 carryover).
+ */
+function readPackageJsonVersion(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const pkgPath = path.resolve(here, "..", "..", "package.json");
+  const raw = fs.readFileSync(pkgPath, "utf8");
+  const parsed = JSON.parse(raw) as { readonly version?: unknown };
+  if (typeof parsed.version !== "string" || parsed.version.length === 0) {
+    throw new Error(`package.json at ${pkgPath} has no usable 'version'`);
+  }
+  return parsed.version;
+}
 
 interface WorkspaceHandle {
   readonly path: string;
@@ -116,7 +138,12 @@ describe("e2e / B / dist/server.js — protocol handshake", () => {
     };
     expect(result.protocolVersion).toBe("2024-11-05");
     expect(result.serverInfo.name).toBe("recall");
-    expect(typeof result.serverInfo.version).toBe("string");
+    // VALUES not SHAPE: the version must match the on-disk
+    // `code/package.json#version`. The previous
+    // `typeof === "string"` assertion silently accepted the stale
+    // `0.1.2-beta.3` literal that lived inline in the bootstrap
+    // and drifted out of sync across the beta.4 and beta.5 bumps.
+    expect(result.serverInfo.version).toBe(readPackageJsonVersion());
     expect(result.capabilities.tools).toBeDefined();
   });
 

--- a/code/tests/e2e/_helpers/binary-harness.ts
+++ b/code/tests/e2e/_helpers/binary-harness.ts
@@ -145,6 +145,21 @@ export function setupBinaryHarness(): {
     }
   }
 
+  // Copy `package.json` so the bootstrap's `resolvePackageVersion()`
+  // can read the version field at runtime. Without this, the
+  // resolver falls through to the `0.0.0-unknown` sentinel and the
+  // handshake reports the wrong version on `initialize.serverInfo`.
+  // The staging layout `<staging>/code/dist/server.js` mirrors the
+  // npm-install layout `<prefix>/lib/node_modules/@netzi/recall/dist/server.js`,
+  // so `..` from `dist/` lands on the package root in both cases.
+  const realPackageJson = path.resolve(REAL_DIST, "..", "package.json");
+  if (fs.existsSync(realPackageJson)) {
+    fs.copyFileSync(
+      realPackageJson,
+      path.join(stagingRoot, "code", "package.json"),
+    );
+  }
+
   // Copy migrations (tiny — six SQL files).
   const stagedMigrations = path.join(stagingRoot, "migrations");
   if (!fs.existsSync(stagedMigrations)) {

--- a/code/tests/unit/bootstrap/composition-root.test.ts
+++ b/code/tests/unit/bootstrap/composition-root.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the bootstrap helpers exposed by
+ * `code/src/bootstrap/composition-root.ts`.
+ *
+ * Covers the `resolvePackageVersion()` helper introduced to close
+ * the cosmetic carryover documented in HANDOFF §0 (and §6.20):
+ * the JSON-RPC `initialize.serverInfo.version` literal drifted out
+ * of sync with `code/package.json` on the beta.4 and beta.5 bumps
+ * because the literal lived inline in the bootstrap and required
+ * disciplinary re-edit on every release.
+ *
+ * The tests use VALUES, not SHAPE (Phase-9 rule): asserting that the
+ * helper returns the EXACT version string read from the on-disk
+ * `package.json`, not just "a non-empty string".
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { resolvePackageVersion } from "../../../src/bootstrap/composition-root.ts";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Reads the `version` field from `code/package.json` (the on-disk
+ * source of truth). The test file lives at
+ * `code/tests/unit/bootstrap/composition-root.test.ts`, so three
+ * `..` reach the `code/` directory.
+ */
+function readPackageJsonVersion(): string {
+  const pkgPath = path.resolve(HERE, "..", "..", "..", "package.json");
+  const raw = fs.readFileSync(pkgPath, "utf8");
+  const parsed = JSON.parse(raw) as { readonly version?: unknown };
+  if (typeof parsed.version !== "string" || parsed.version.length === 0) {
+    throw new Error(
+      `package.json at ${pkgPath} has no usable 'version' field`,
+    );
+  }
+  return parsed.version;
+}
+
+describe("resolvePackageVersion", () => {
+  it("returns the version that lives in code/package.json", () => {
+    const expected = readPackageJsonVersion();
+    const actual = resolvePackageVersion();
+    expect(actual).toBe(expected);
+  });
+
+  it("returns a non-empty string (defensive — guards against the unknown sentinel leaking on a healthy install)", () => {
+    const actual = resolvePackageVersion();
+    expect(actual).not.toBe("");
+    // The `0.0.0-unknown` sentinel signals that the helper could not
+    // locate or parse `package.json`. Receiving it from a healthy
+    // checkout would mean the helper's resolution chain is broken.
+    expect(actual).not.toBe("0.0.0-unknown");
+  });
+
+  it("returns a SemVer-shaped string (defensive — catches accidental refactors that return e.g. the package name)", () => {
+    const actual = resolvePackageVersion();
+    // Loose SemVer: <digits>.<digits>.<digits> with optional
+    // pre-release tag. Tight enough to catch "name leaked through"
+    // regressions, loose enough to accept beta tags / build metadata.
+    expect(actual).toMatch(/^\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?$/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the cosmetic carryover tracked in HANDOFF §0 + §6.20 "Siguiente accion concreta" #1: the JSON-RPC `initialize.serverInfo.version` literal lived inline in `bootstrapComposition` and required disciplinary re-edit on every release. The discipline failed twice — beta.4 and beta.5 both shipped reporting `0.1.2-beta.3`. This PR eliminates the source of the drift by reading the version from `package.json` at boot.

Unblocks cutting `release/0.1.2` stable (mentioned as pre-stable cleanup in HANDOFF §6.20).

## Why it escaped tests

The previous E2E assertion was `expect(typeof serverInfo.version).toBe("string")` — a textbook SHAPE-not-VALUES regression. The Phase-9 rule "VALORES no SHAPE" wasn't applied here originally. Tightening the assertion is part of this PR.

## Fix

### `resolvePackageVersion()` helper

New helper in `composition-root.ts` (exported for tests). Resolution mirrors `resolveDefaultMigrationsDir()` (B-CLI-5 pattern):

1. **Anchored on `argv[1]`** (with `fs.realpathSync` for npm-global symlinks). Tries sibling-of-`dist/` then sibling-of-`src/`.
2. **Anchored on `import.meta.url`** (unit tests + tsx-imported bootstrap paths where `argv[1]` doesn't point at this module).

### Defences

- **Validates `name === "@netzi/recall"`** on each candidate. Without this, the unit test suite caught the resolver returning vitest's own `1.1.1` (anchored on `argv[1]` pointing at the vitest binary). The name guard is also defence-in-depth against custom Node launchers.
- **Returns `0.0.0-unknown` sentinel** if no candidate parses cleanly. The bootstrap never blocks on missing package metadata; the obviously-fake string surfaces on the handshake so any client inspecting `initialize` can flag the install as broken.

### Replaced the literal

```diff
  const serverInfo = options.serverInfo ?? {
    name: "recall",
-   // Kept in lockstep with `code/package.json` `version`. A future
-   // refactor can read this at build time via tsup; the literal is
-   // adequate for now and avoids a runtime require/import of the
-   // package metadata.
-   version: "0.1.2-beta.3",
+   // Read from `package.json` at boot rather than hardcoded — see
+   // {@link resolvePackageVersion} for the rationale and the
+   // failed-discipline incidents this avoids.
+   version: resolvePackageVersion(),
    protocolVersion: "2024-11-05",
  };
```

## Tests (VALUES not SHAPE)

- **New unit suite** `code/tests/unit/bootstrap/composition-root.test.ts` (3 tests):
  - Exact-match against `code/package.json#version`.
  - Non-empty + non-sentinel guard (catches the resolver chain breaking on a healthy install).
  - SemVer-shape regex (catches refactors that accidentally return e.g. the package name).
- **Tightened existing E2E** in `B-mcp-server-binary.test.ts`:
  ```diff
  - expect(typeof result.serverInfo.version).toBe("string");
  + expect(result.serverInfo.version).toBe(readPackageJsonVersion());
  ```
- **E2E harness fix**: `binary-harness.ts` now copies `code/package.json` to the staging tree (`<staging>/code/package.json`) so the bundled binary's resolver finds the same version string the test asserts. The staging layout `<staging>/code/dist/server.js` mirrors the npm-install layout `<prefix>/lib/node_modules/@netzi/recall/dist/server.js`, so the resolver path (`..` from `dist/`) lands on the package root in both cases.

## Validation

| Check | Result |
|---|---|
| `npm run typecheck` | EXIT=0 |
| `npm run lint` (max-warnings 0) | EXIT=0 |
| `npm run lint:tests` (max-warnings 0) | EXIT=0 |
| `npm run validate:modules` | PASS — no module violations |
| `npm run build` (tsup) | EXIT=0 |
| `npm test` | **2560 passing** in 212 files (+3 vs 2557 baseline) |

## Test plan

- [x] Pre-fix unit test reproducing the bug — fails on `develop` with `expected '0.1.2-beta.3' to be '0.1.2-beta.5'`.
- [x] Post-fix unit test passes (3/3).
- [x] Pre-fix E2E test reproducing the bug — would fail on `develop` with the same drift.
- [x] Post-fix E2E test passes (18/18).
- [x] Full suite passes (2560/2560).
- [ ] CI green on this PR.
- [ ] Squash-merge to develop.
- [ ] Next: cut `release/0.1.2` stable now that the only pre-stable carryover is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)