### PR TITLE
feat(workspace): chmod 0o600 sobre recall.db (W-3.5-SEC-M2)

### DIFF
--- a/code/src/modules/workspace/infrastructure/persistence/sqlite-database-bootstrap.ts
+++ b/code/src/modules/workspace/infrastructure/persistence/sqlite-database-bootstrap.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from "node:fs";
 import * as path from "node:path";
 
 import type { Logger } from "../../../../shared/application/ports/logger.port.ts";
@@ -15,6 +16,17 @@ import type {
   DatabaseBootstrapResult,
   DatabaseProbeResult,
 } from "../../application/ports/out/database-bootstrap.port.ts";
+
+/**
+ * Permission bits for the workspace SQLite file. Mirrors
+ * `CONFIG_FILE_MODE` in `node-workspace-filesystem.ts` and is documented
+ * in `docs/11-seguridad-modos.md` §7. Defense-in-depth: the parent
+ * directory is already 0o700, but applying chmod here is idempotent
+ * and protects against umask drift or filesystems that materialise the
+ * file with broader permissions during `open()`. No-op on Windows
+ * (per Node `fs.chmod` semantics).
+ */
+const DATABASE_FILE_MODE = 0o600;
 
 /**
  * Adapter that bootstraps and probes the workspace's SQLite
@@ -73,6 +85,11 @@ export class SqliteDatabaseBootstrap implements DatabaseBootstrap {
       logger: this.options.logger,
     });
     try {
+      // Defense-in-depth: ensure recall.db is owner-only readable/writable.
+      // The parent directory is already 0o700, but chmod here is idempotent
+      // and protects against umask drift or filesystems that materialize the
+      // file with broader permissions during open(). No-op on Windows.
+      await fs.chmod(databasePath, DATABASE_FILE_MODE);
       const runner = new MigrationsRunner(this.options.logger);
       const result: MigrationsResult = await runner.run(
         db,

--- a/code/tests/unit/workspace/infrastructure/persistence/sqlite-database-bootstrap.test.ts
+++ b/code/tests/unit/workspace/infrastructure/persistence/sqlite-database-bootstrap.test.ts
@@ -7,6 +7,7 @@ import { SqliteDatabaseBootstrap } from "../../../../../src/modules/workspace/in
 import { WorkspaceMode } from "../../../../../src/modules/workspace/domain/value-objects/workspace-mode.ts";
 import { WorkspacePath } from "../../../../../src/modules/workspace/domain/value-objects/workspace-path.ts";
 import type { Logger } from "../../../../../src/shared/application/ports/logger.port.ts";
+import type { EncryptionKeyBytes } from "../../../../../src/shared/infrastructure/database/sqlite-database.ts";
 
 class SilentLogger implements Logger {
   public trace(): void {}
@@ -169,5 +170,95 @@ describe("SqliteDatabaseBootstrap", () => {
       mode: WorkspaceMode.privateMode(),
     });
     expect(captured).toBe("private");
+  });
+});
+
+describe("SqliteDatabaseBootstrap — recall.db chmod 0o600 (W-3.5-SEC-M2)", () => {
+  // chmod is a no-op on Windows per Node `fs.chmod` docs; permission
+  // bits are not meaningful on NTFS via this API, so we skip the
+  // VALUE-not-SHAPE assertion entirely on win32 to avoid false negatives.
+
+  it("bootstrap sets recall.db mode to 0o600 in shared mode", async () => {
+    if (process.platform === "win32") return;
+    const adapter = new SqliteDatabaseBootstrap({
+      migrationsDir: ctx.migrationsDir,
+      keyResolver: () => Promise.resolve(null),
+      logger: new SilentLogger(),
+    });
+    await adapter.bootstrap({
+      rootPath: WorkspacePath.create(ctx.tmpDir),
+      mode: WorkspaceMode.sharedMode(),
+    });
+    const dbPath = path.join(ctx.tmpDir, ".recall", "recall.db");
+    const stat = await fs.stat(dbPath);
+    // VALUE not SHAPE: assert the actual permission bits are 0o600.
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("bootstrap sets recall.db mode to 0o600 in private mode", async () => {
+    if (process.platform === "win32") return;
+    const adapter = new SqliteDatabaseBootstrap({
+      migrationsDir: ctx.migrationsDir,
+      keyResolver: () => Promise.resolve(null),
+      logger: new SilentLogger(),
+    });
+    await adapter.bootstrap({
+      rootPath: WorkspacePath.create(ctx.tmpDir),
+      mode: WorkspaceMode.privateMode(),
+    });
+    const dbPath = path.join(ctx.tmpDir, ".recall", "recall.db");
+    const stat = await fs.stat(dbPath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("bootstrap sets recall.db mode to 0o600 in encrypted mode", async () => {
+    if (process.platform === "win32") return;
+    // Provide a deterministic 32-byte key so SqliteDatabase.open
+    // applies SQLCipher pragmas. The chmod must happen regardless of
+    // whether the workspace is encrypted (the file still lands on the
+    // host filesystem with the same permission concerns).
+    const key: EncryptionKeyBytes = { bytes: new Uint8Array(32).fill(0x42) };
+    const adapter = new SqliteDatabaseBootstrap({
+      migrationsDir: ctx.migrationsDir,
+      keyResolver: () => Promise.resolve(key),
+      logger: new SilentLogger(),
+    });
+    await adapter.bootstrap({
+      rootPath: WorkspacePath.create(ctx.tmpDir),
+      mode: WorkspaceMode.encryptedMode(),
+    });
+    const dbPath = path.join(ctx.tmpDir, ".recall", "recall.db");
+    const stat = await fs.stat(dbPath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("bootstrap chmod is idempotent across repeated runs", async () => {
+    if (process.platform === "win32") return;
+    const adapter = new SqliteDatabaseBootstrap({
+      migrationsDir: ctx.migrationsDir,
+      keyResolver: () => Promise.resolve(null),
+      logger: new SilentLogger(),
+    });
+    const dbPath = path.join(ctx.tmpDir, ".recall", "recall.db");
+
+    await adapter.bootstrap({
+      rootPath: WorkspacePath.create(ctx.tmpDir),
+      mode: WorkspaceMode.sharedMode(),
+    });
+    const first = await fs.stat(dbPath);
+    expect(first.mode & 0o777).toBe(0o600);
+
+    // Loosen the bits to simulate umask drift / external interference,
+    // then re-bootstrap and verify the second run tightens back to 0o600.
+    await fs.chmod(dbPath, 0o644);
+    const drifted = await fs.stat(dbPath);
+    expect(drifted.mode & 0o777).toBe(0o644);
+
+    await adapter.bootstrap({
+      rootPath: WorkspacePath.create(ctx.tmpDir),
+      mode: WorkspaceMode.sharedMode(),
+    });
+    const second = await fs.stat(dbPath);
+    expect(second.mode & 0o777).toBe(0o600);
   });
 });


### PR DESCRIPTION
## Summary

First fix of the **v0.5 hardening cycle** (HANDOFF.md §6.21 roadmap row 4). Closes warning **W-3.5-SEC-M2** identified in Phase 3 architect review and deferred to v0.5 (HANDOFF §6.7 D-310).

Adds explicit `chmod 0o600` on `recall.db` immediately after `SqliteDatabase.open` returns, inside the migrations `try` block (so cleanup in `finally` still runs if chmod fails).

## Why defense-in-depth (not security theater)

The parent directory `.recall/` is already at `0o700`, but the file-mode chmod adds genuine value in scenarios where the file outlives its directory or is observed independently:

- **Umask drift**: with default `umask 022`, SQLite materializes the file at `0o644` before chmod tightens it.
- **Backups/snapshots/copies**: `cp`, `mv`, `tar`, `restic`, `borg`, `zfs send`, APFS/btrfs snapshots all preserve file mode. The 0o600 travels with the file.
- **Cross-volume restores**: filesystem snapshots restored to a new volume keep file mode but recreate directory mode from the mount.

Mirrors the existing `CONFIG_FILE_MODE` pattern in `node-workspace-filesystem.ts:23` for consistency.

## What changed

- `code/src/modules/workspace/infrastructure/persistence/sqlite-database-bootstrap.ts` (+17 LOC) — import `node:fs` promises, declare `DATABASE_FILE_MODE = 0o600`, add `await fs.chmod(databasePath, DATABASE_FILE_MODE)` inside the existing `try` block.
- `code/tests/unit/workspace/infrastructure/persistence/sqlite-database-bootstrap.test.ts` (+91 LOC) — 4 new tests, all VALUE-asserting `(stat.mode & 0o777) === 0o600`:
  - shared / private / encrypted modes (3 tests)
  - idempotency: simulate umask drift (`chmod 0o644`), re-bootstrap, expect `0o600`

Skipped on Windows (`fs.chmod` is no-op per Node docs); pattern matches 8+ existing tests in `node-workspace-filesystem.test.ts`.

## Security audit result

**APPROVED WITH OBSERVATIONS** (security-auditor). 4 non-blocking observations tracked for future iterations:

- **O-1 (LOW)**: TOCTOU window between `BetterSqlite3` open (creates file at `0o644 & ~umask`) and `fs.chmod`. Mitigated by parent dir `0o700` + same-UID DAC (any same-UID process can read regardless of mode bits). Optional future fix: pre-create file with `O_CREAT | O_EXCL | mode=0o600` before SQLite opens.
- **O-2 (INFO)**: chmod failure surfaces as raw Node error vs wrapped `DatabaseError`. Minor inconsistency.
- **O-3 (INFO)**: No test asserts cleanup-on-chmod-failure invariant (placement in `try` block is correct in code but not pinned by test).
- **O-4 (INFO)**: 3 mode-tests duplicate the chmod assertion — accepted as cheap insurance pinning the contract per mode.

These will be tracked in HANDOFF.md when the v0.5 hardening cycle closes.

## Test plan

- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` EXIT=0 (--max-warnings 0)
- [x] `npm run lint:tests` EXIT=0 (--max-warnings 0)
- [x] `npm run validate:modules` EXIT=0 (no module violations)
- [x] `npm run build` EXIT=0
- [x] `npm test` EXIT=0 — **2564/2564 tests pass** (+4 vs baseline)
- [x] CI required status check `ci`
- [x] SonarQube quality gate `MCP Memoria Strict`

## OWASP mapping

- **A05:2021 Security Misconfiguration** — actively closed (umask drift was the risk).
- **A01:2021 Broken Access Control** — strengthened (chmod tightens DAC at file level).
- No A02/A07 impact (crypto path untouched, no key flows through chmod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)