### PR TITLE
feat(workspace): atomic write+rename en .gitignore + writeConfig (W-3.5-SEC-M1)

### DIFF
--- a/code/src/modules/workspace/infrastructure/filesystem/node-workspace-filesystem.ts
+++ b/code/src/modules/workspace/infrastructure/filesystem/node-workspace-filesystem.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import { randomBytes } from "node:crypto";
 import * as path from "node:path";
 import * as os from "node:os";
 import { z } from "zod";
@@ -81,12 +82,22 @@ type RawConfig = z.infer<typeof PERSISTED_CONFIG_SCHEMA>;
  *     names).
  *
  * Atomicity:
- *   - `writeConfig` writes to a temporary sibling file in the same
- *     directory as the canonical name and renames atomically. Same
- *     filesystem guarantees `rename(2)` is atomic.
- *   - The temporary suffix is randomised via `os.tmpdir`-like seed
- *     (we use `process.pid + Date.now()`) to avoid collisions when
- *     two CLIs initialise concurrently.
+ *   - `writeConfig` and `ensureGitignore` route every durable write
+ *     through `atomicWriteFile`, which writes to a temporary sibling
+ *     file in the **same directory** as the canonical name and renames
+ *     atomically. Same-filesystem rename(2) is atomic on POSIX —
+ *     readers see either the previous content or the new content,
+ *     never partial. The temp file lives next to the target precisely
+ *     so the rename stays within one filesystem (`os.tmpdir()` may sit
+ *     on a different mount).
+ *   - The temporary suffix combines `process.pid` with 6 bytes from
+ *     `crypto.randomBytes` to avoid collisions when two CLIs
+ *     initialise concurrently against the same workspace.
+ *   - This closes warning W-3.5-SEC-M1 (HANDOFF.md §6.7 D-310): a
+ *     mid-write crash or `SIGKILL` on the previous direct-`writeFile`
+ *     to `.gitignore` could leave the file truncated, dropping the
+ *     `.recall/` entry the `private` mode relies on to keep the DB
+ *     out of git.
  *
  * Concurrency:
  *   - The adapter does NOT take any process-level lock. Concurrent
@@ -171,11 +182,6 @@ export class NodeWorkspaceFilesystem implements WorkspaceFilesystem {
     config: PersistedWorkspaceConfig,
   ): Promise<void> {
     const configPath = NodeWorkspaceFilesystem.configFilePath(rootPath);
-    const dir = path.dirname(configPath);
-    const tempPath = path.join(
-      dir,
-      `.${CONFIG_FILE_NAME}.tmp-${String(process.pid)}-${String(Date.now())}`,
-    );
 
     // Preserve unknown sub-slices (encryption, secrets, retrieval,
     // curator) when re-writing. Reading the existing file (when
@@ -215,15 +221,8 @@ export class NodeWorkspaceFilesystem implements WorkspaceFilesystem {
 
     const json = `${JSON.stringify(merged, null, 2)}\n`;
     try {
-      await fs.writeFile(tempPath, json, {
-        encoding: "utf8",
-        mode: CONFIG_FILE_MODE,
-      });
-      await fs.chmod(tempPath, CONFIG_FILE_MODE);
-      await fs.rename(tempPath, configPath);
+      await this.atomicWriteFile(configPath, json, CONFIG_FILE_MODE);
     } catch (err: unknown) {
-      // Best-effort cleanup of the temp file.
-      await fs.unlink(tempPath).catch(() => undefined);
       throw WorkspaceInfrastructureError.configWriteFailed(
         rootPath.toString(),
         err,
@@ -288,7 +287,10 @@ export class NodeWorkspaceFilesystem implements WorkspaceFilesystem {
       const expected = NodeWorkspaceFilesystem.withGitignoreEntry(content);
       if (expected === content) return; // already consistent
       try {
-        await fs.writeFile(gitignorePath, expected, "utf8");
+        // Atomic write: a crash mid-write must NOT leave `.gitignore`
+        // truncated, because in `private` mode that file is the only
+        // guard keeping `.recall/recall.db` out of git (W-3.5-SEC-M1).
+        await this.atomicWriteFile(gitignorePath, expected);
       } catch (err: unknown) {
         throw WorkspaceInfrastructureError.gitignoreUpdateFailed(
           rootPath.toString(),
@@ -309,7 +311,9 @@ export class NodeWorkspaceFilesystem implements WorkspaceFilesystem {
         // earlier; remove it.
         await fs.unlink(gitignorePath);
       } else {
-        await fs.writeFile(gitignorePath, without, "utf8");
+        // Atomic write: same reasoning as the private branch above —
+        // a crash mid-write must not leave a partial `.gitignore`.
+        await this.atomicWriteFile(gitignorePath, without);
       }
     } catch (err: unknown) {
       throw WorkspaceInfrastructureError.gitignoreUpdateFailed(
@@ -320,6 +324,60 @@ export class NodeWorkspaceFilesystem implements WorkspaceFilesystem {
   }
 
   // ── helpers ───────────────────────────────────────────────────────
+
+  /**
+   * Write `content` to `targetPath` atomically by writing to a
+   * randomised sibling temp file first, then renaming. POSIX
+   * `rename(2)` is atomic when source and target sit on the same
+   * filesystem — that is why the temp path is built from
+   * `path.dirname(targetPath)`, never from `os.tmpdir()` (which can be
+   * a different mount and would force a copy-then-unlink that is NOT
+   * atomic).
+   *
+   * On rename failure the temp file is unlinked best-effort. The
+   * unlink failure is intentionally swallowed (e.g. ENOENT if
+   * something else cleaned it up) so the original cause surfaces to
+   * the caller.
+   *
+   * If `mode` is provided, it is applied to the temp file before the
+   * rename so the visible target inherits restrictive bits regardless
+   * of the inherited umask. If `mode` is omitted, the system default
+   * (umask-derived, typically `0o644`) applies — appropriate for
+   * non-secret files like the host project's `.gitignore` which
+   * should remain readable by tooling.
+   *
+   * Closes warning W-3.5-SEC-M1 (HANDOFF.md §6.7 D-310).
+   */
+  private async atomicWriteFile(
+    targetPath: string,
+    content: string,
+    mode?: number,
+  ): Promise<void> {
+    const dir = path.dirname(targetPath);
+    const base = path.basename(targetPath);
+    const suffix = randomBytes(6).toString("hex");
+    const tempPath = path.join(
+      dir,
+      `.${base}.tmp-${String(process.pid)}-${suffix}`,
+    );
+    const writeOptions: { encoding: "utf8"; mode?: number } = {
+      encoding: "utf8",
+      ...(mode !== undefined ? { mode } : {}),
+    };
+    try {
+      await fs.writeFile(tempPath, content, writeOptions);
+      if (mode !== undefined) {
+        // `writeFile`'s `mode` only applies on creation; reapply
+        // explicitly so a pre-existing temp file (collision with a
+        // dead PID's leftover) is also tightened.
+        await fs.chmod(tempPath, mode);
+      }
+      await fs.rename(tempPath, targetPath);
+    } catch (cause) {
+      await fs.unlink(tempPath).catch(() => undefined);
+      throw cause;
+    }
+  }
 
   private static workspaceDirPath(rootPath: WorkspacePath): string {
     const joined = rootPath.join(WORKSPACE_DIRECTORY_NAME).toString();

--- a/code/src/modules/workspace/infrastructure/filesystem/node-workspace-filesystem.ts
+++ b/code/src/modules/workspace/infrastructure/filesystem/node-workspace-filesystem.ts
@@ -362,7 +362,7 @@ export class NodeWorkspaceFilesystem implements WorkspaceFilesystem {
     );
     const writeOptions: { encoding: "utf8"; mode?: number } = {
       encoding: "utf8",
-      ...(mode !== undefined ? { mode } : {}),
+      ...(mode === undefined ? {} : { mode }),
     };
     try {
       await fs.writeFile(tempPath, content, writeOptions);

--- a/code/tests/unit/workspace/infrastructure/filesystem/node-workspace-filesystem.test.ts
+++ b/code/tests/unit/workspace/infrastructure/filesystem/node-workspace-filesystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -399,5 +399,294 @@ describe("NodeWorkspaceFilesystem.ensureGitignore", () => {
     } finally {
       await fs.chmod(cfgPath, 0o600).catch(() => undefined);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// W-3.5-SEC-M1 — atomic write+rename for `.gitignore` (and `config.json`)
+// Pin the contract: every durable write goes through write-temp-then-
+// rename so a crash mid-write never leaves the canonical file truncated.
+// In `private` mode `.gitignore` is the *only* guard keeping
+// `.recall/recall.db` out of git, so a partial write is a real
+// security regression — these tests pin the invariant.
+// ─────────────────────────────────────────────────────────────────────
+describe("NodeWorkspaceFilesystem.ensureGitignore — atomic write contract (W-3.5-SEC-M1)", () => {
+  it("private: final .gitignore content equals the new content (no truncation, no leftover bytes from a previous longer file)", async () => {
+    // Seed with a longer file than the post-write content. If the
+    // implementation ever switched to truncate-then-write, an
+    // interrupted write would leave a shorter-than-expected file. Here
+    // we simply verify the post-condition: content is exactly what we
+    // wrote, byte-for-byte.
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    const longExisting = "node_modules\nbuild/\ndist/\n.env\n.cache/\nlogs/\ntmp/\n";
+    await fs.writeFile(gitignorePath, longExisting, "utf8");
+
+    await fsAdapter.ensureGitignore(ctx.rootPath, WorkspaceMode.privateMode());
+
+    const after = await fs.readFile(gitignorePath, "utf8");
+    // VALOR: every original line is preserved, plus the new entry,
+    // and the file ends with a newline.
+    expect(after).toBe(`${longExisting}.recall/\n`);
+  });
+
+  it("private: no leftover temp file (`.gitignore.tmp-*`) survives a successful write", async () => {
+    await fsAdapter.ensureGitignore(ctx.rootPath, WorkspaceMode.privateMode());
+    const entries = await fs.readdir(ctx.tmpDir);
+    // VALOR: the only entry in the tmp dir is the canonical
+    // `.gitignore` — no orphan `.gitignore.tmp-...` left behind.
+    const tmpLeftovers = entries.filter((e) => /\.gitignore\.tmp-/.test(e));
+    expect(tmpLeftovers).toEqual([]);
+    expect(entries).toContain(".gitignore");
+  });
+
+  it("private: temp file lives in the same directory as the target (so rename(2) is single-filesystem)", async () => {
+    // Pin behaviour: spy on `fs.rename` to capture the temp path used
+    // and assert it is a sibling of the target. If a future refactor
+    // routed the temp via `os.tmpdir()` (different mount), this test
+    // would fail.
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    const renameSpy = vi.spyOn(fs, "rename");
+    try {
+      await fsAdapter.ensureGitignore(ctx.rootPath, WorkspaceMode.privateMode());
+      expect(renameSpy).toHaveBeenCalled();
+      const firstCall = renameSpy.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const [tempPath, finalPath] = firstCall as [string, string];
+      // VALOR: temp lives in the same directory as the target → same
+      // filesystem → atomic rename guarantee holds.
+      expect(path.dirname(tempPath)).toBe(path.dirname(gitignorePath));
+      expect(finalPath).toBe(gitignorePath);
+      // VALOR: temp filename is hidden (dot-prefixed) and contains the
+      // PID — the documented naming pattern.
+      expect(path.basename(tempPath)).toMatch(
+        /^\.\.gitignore\.tmp-\d+-[0-9a-f]{12}$/,
+      );
+    } finally {
+      renameSpy.mockRestore();
+    }
+  });
+
+  it("private: when fs.rename fails, the temp file is unlinked and the canonical .gitignore is unchanged", async () => {
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    const originalContent = "node_modules\n";
+    await fs.writeFile(gitignorePath, originalContent, "utf8");
+
+    // Force `fs.rename` to fail. We capture the temp path it was given
+    // so we can assert the cleanup actually unlinked it.
+    let observedTempPath: string | null = null;
+    const renameSpy = vi
+      .spyOn(fs, "rename")
+      .mockImplementation(async (src) => {
+        observedTempPath = String(src);
+        throw Object.assign(new Error("synthetic rename failure"), {
+          code: "EXDEV",
+        });
+      });
+    try {
+      const e = await fsAdapter
+        .ensureGitignore(ctx.rootPath, WorkspaceMode.privateMode())
+        .then(
+          () => null,
+          (err: unknown) => err,
+        );
+      // VALOR: error is wrapped — caller learns the write failed.
+      expect(e).toBeInstanceOf(WorkspaceInfrastructureError);
+      expect((e as WorkspaceInfrastructureError).code).toBe(
+        "workspace.gitignore-update-failed",
+      );
+
+      // VALOR: the canonical `.gitignore` is byte-identical to its
+      // pre-call content — the failed write did NOT corrupt it.
+      const afterText = await fs.readFile(gitignorePath, "utf8");
+      expect(afterText).toBe(originalContent);
+
+      // VALOR: the temp file was cleaned up (no leftover on disk).
+      expect(observedTempPath).not.toBeNull();
+      const tempStillExists = await fs
+        .stat(observedTempPath as unknown as string)
+        .then(() => true)
+        .catch(() => false);
+      expect(tempStillExists).toBe(false);
+
+      // VALOR: directory listing has no `.gitignore.tmp-*` orphans.
+      const entries = await fs.readdir(ctx.tmpDir);
+      const tmpLeftovers = entries.filter((e) =>
+        /\.gitignore\.tmp-/.test(e),
+      );
+      expect(tmpLeftovers).toEqual([]);
+    } finally {
+      renameSpy.mockRestore();
+    }
+  });
+
+  it("shared: removing the entry also goes through atomic write — temp file lives next to target and is cleaned up", async () => {
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    await fs.writeFile(gitignorePath, "node_modules\n.recall/\nbuild/\n", "utf8");
+    const renameSpy = vi.spyOn(fs, "rename");
+    try {
+      await fsAdapter.ensureGitignore(
+        ctx.rootPath,
+        WorkspaceMode.sharedMode(),
+      );
+      // VALOR: the rename call did happen — write went through
+      // temp+rename, not direct writeFile.
+      expect(renameSpy).toHaveBeenCalled();
+      const firstCall = renameSpy.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const [tempPath, finalPath] = firstCall as [string, string];
+      expect(path.dirname(tempPath)).toBe(path.dirname(gitignorePath));
+      expect(finalPath).toBe(gitignorePath);
+
+      // VALOR: final content is the new content with the entry stripped.
+      const after = await fs.readFile(gitignorePath, "utf8");
+      expect(after).not.toContain(".recall/");
+      expect(after).toContain("node_modules");
+      expect(after).toContain("build/");
+
+      // VALOR: no temp leftovers.
+      const entries = await fs.readdir(ctx.tmpDir);
+      const tmpLeftovers = entries.filter((e) =>
+        /\.gitignore\.tmp-/.test(e),
+      );
+      expect(tmpLeftovers).toEqual([]);
+    } finally {
+      renameSpy.mockRestore();
+    }
+  });
+
+  it("private: appending the entry to an existing .gitignore preserves every prior byte verbatim", async () => {
+    // Specific concurrency-safety check: a non-atomic implementation
+    // doing `truncate + write` could lose bytes if interrupted. The
+    // atomic helper produces the new file in full at the temp path
+    // BEFORE rename, so the canonical file is never observed in a
+    // partial state. We pin the post-condition: every original byte
+    // is preserved, the new entry is appended.
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    const original = "node_modules\nbuild/\n";
+    await fs.writeFile(gitignorePath, original, "utf8");
+
+    await fsAdapter.ensureGitignore(ctx.rootPath, WorkspaceMode.privateMode());
+
+    const after = await fs.readFile(gitignorePath, "utf8");
+    // VALOR: prefix is byte-identical to the original.
+    expect(after.startsWith(original)).toBe(true);
+    // VALOR: suffix is exactly the new entry plus newline.
+    expect(after.slice(original.length)).toBe(".recall/\n");
+  });
+
+  it("writeConfig: also routes through atomic temp+rename (writeFile target is the temp path, not the canonical config.json)", async () => {
+    // Symmetry check: `writeConfig` must use the same atomic-write
+    // path as `ensureGitignore`. We assert by spying on `fs.rename`
+    // and verifying both: (1) rename was called and (2) the source
+    // path is a sibling of the canonical `config.json` (so it lives
+    // in `.recall/`, same filesystem).
+    await fsAdapter.createWorkspaceDirectory(ctx.rootPath);
+    const configPath = path.join(ctx.tmpDir, ".recall", "config.json");
+    const renameSpy = vi.spyOn(fs, "rename");
+    try {
+      await fsAdapter.writeConfig(ctx.rootPath, SAMPLE);
+      expect(renameSpy).toHaveBeenCalled();
+      const firstCall = renameSpy.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const [tempPath, finalPath] = firstCall as [string, string];
+      // VALOR: temp lives in `.recall/` next to the target.
+      expect(path.dirname(tempPath)).toBe(path.dirname(configPath));
+      expect(finalPath).toBe(configPath);
+      // VALOR: temp filename matches the new randomBytes-based pattern.
+      expect(path.basename(tempPath)).toMatch(
+        /^\.config\.json\.tmp-\d+-[0-9a-f]{12}$/,
+      );
+    } finally {
+      renameSpy.mockRestore();
+    }
+  });
+
+  it("writeConfig: rename failure leaves no temp file behind and surfaces configWriteFailed", async () => {
+    await fsAdapter.createWorkspaceDirectory(ctx.rootPath);
+    let observedTempPath: string | null = null;
+    const renameSpy = vi
+      .spyOn(fs, "rename")
+      .mockImplementation(async (src) => {
+        observedTempPath = String(src);
+        throw Object.assign(new Error("synthetic rename failure"), {
+          code: "EXDEV",
+        });
+      });
+    try {
+      const e = await fsAdapter
+        .writeConfig(ctx.rootPath, SAMPLE)
+        .then(
+          () => null,
+          (err: unknown) => err,
+        );
+      // VALOR: error is wrapped as configWriteFailed.
+      expect(e).toBeInstanceOf(WorkspaceInfrastructureError);
+      expect((e as WorkspaceInfrastructureError).code).toBe(
+        "workspace.config-write-failed",
+      );
+
+      // VALOR: temp file was cleaned up (best-effort unlink succeeded).
+      expect(observedTempPath).not.toBeNull();
+      const tempStillExists = await fs
+        .stat(observedTempPath as unknown as string)
+        .then(() => true)
+        .catch(() => false);
+      expect(tempStillExists).toBe(false);
+    } finally {
+      renameSpy.mockRestore();
+    }
+  });
+
+  it("writeConfig: file mode 0o600 is preserved end-to-end through atomic rename", async () => {
+    if (process.platform === "win32") return;
+    await fsAdapter.createWorkspaceDirectory(ctx.rootPath);
+    await fsAdapter.writeConfig(ctx.rootPath, SAMPLE);
+    const stat = await fs.stat(
+      path.join(ctx.tmpDir, ".recall", "config.json"),
+    );
+    // VALOR: the rename did not lose the restrictive mode set on the
+    // temp file. POSIX rename preserves inode (and therefore mode).
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("ensureGitignore: concurrent invocations both succeed and final content is one of the two valid states (atomicity invariant)", async () => {
+    // We cannot reliably reproduce a "torn write" with real fs because
+    // the helper writes the *whole* content to the temp file before
+    // rename. Instead we pin the post-atomicity invariant: under
+    // concurrent invocations the final canonical file is always one
+    // of the legal end-states (never a truncated/garbage hybrid). A
+    // non-atomic implementation could interleave write() syscalls and
+    // produce content like ".reca.recall/\n".
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    await fs.writeFile(gitignorePath, "node_modules\n", "utf8");
+
+    // Run 8 concurrent ensureGitignore calls in private mode. They
+    // should all complete; the canonical end-state is deterministic
+    // (the entry is present exactly once + node_modules preserved).
+    await Promise.all(
+      Array.from({ length: 8 }, () =>
+        fsAdapter.ensureGitignore(
+          ctx.rootPath,
+          WorkspaceMode.privateMode(),
+        ),
+      ),
+    );
+
+    const after = await fs.readFile(gitignorePath, "utf8");
+    const recallLines = after
+      .split("\n")
+      .filter((l) => l.trim() === ".recall/");
+    // VALOR: the entry is present at least once and at most once per
+    // ensureGitignore that observed an "absent" state. With the atomic
+    // helper + idempotent withGitignoreEntry this collapses to 1.
+    expect(recallLines.length).toBe(1);
+    // VALOR: original `node_modules` line is still present.
+    expect(after.includes("node_modules\n")).toBe(true);
+    // VALOR: no orphan temp files left behind by any of the 8 races.
+    const entries = await fs.readdir(ctx.tmpDir);
+    const tmpLeftovers = entries.filter((e) =>
+      /\.gitignore\.tmp-/.test(e),
+    );
+    expect(tmpLeftovers).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Second fix of the **v0.5 hardening cycle** (HANDOFF.md §6.21 roadmap row 4). Closes warning **W-3.5-SEC-M1** identified in Phase 3 architect review and deferred to v0.5 (HANDOFF §6.7 D-310).

`ensureGitignore` previously called `fs.writeFile(gitignorePath, ...)` directly. A crash, `SIGKILL`, power loss, or disk-full mid-write can leave a truncated `.gitignore` on disk. In `private` mode that file is the **only guard** keeping `.recall/recall.db` out of git — a truncated file that drops the `.recall/` line silently regresses the workspace's privacy invariant on the next `git add`.

This PR introduces a private helper `atomicWriteFile(targetPath, content, mode?)` that writes to a randomised sibling temp path (`.<base>.tmp-<pid>-<6-bytes-hex>`) and renames atomically (`fs.rename` is atomic on POSIX within the same filesystem). On rename failure the temp file is `unlink`'ed best-effort.

**Scope expansion**: `writeConfig` previously had a partial temp+rename using `Date.now()`. Consolidated through the same helper — uniform pattern + crypto-strong randomness via `crypto.randomBytes(6)`.

## Why this is independent from PR-1 (chmod)

| | PR-1 (W-3.5-SEC-M2) | PR-2 (W-3.5-SEC-M1) |
|---|---|---|
| Risk class | umask drift on file creation | partial writes on crash |
| Closes via | chmod 0o600 after open | write-temp + atomic rename |
| Both apply? | Yes — independent gaps |

## What changed

### Code (\`node-workspace-filesystem.ts\`, +66/-25 LOC net)

- New private helper \`atomicWriteFile(targetPath, content, mode?)\` — temp lives in \`path.dirname(targetPath)\` (same-filesystem rule); CSPRNG suffix; cleanup on rename failure.
- \`ensureGitignore\` private branch + shared/encrypted branch routed through \`atomicWriteFile\`.
- \`writeConfig\` consolidated through the same helper (replaces \`Date.now()\` with \`randomBytes(6)\`; removes duplicate cleanup branch).
- Class docstring updated to document the atomicity invariant.

### Tests (+10 tests, all VALOR)

- final .gitignore content equals new content (no truncation)
- no leftover temp file survives a successful write
- temp file lives in the same directory as the target
- when fs.rename fails (EXDEV), the canonical .gitignore is byte-identical to pre-call + temp cleaned up
- removing the entry also goes through atomic write
- appending preserves every prior byte verbatim
- writeConfig also routes through atomic temp+rename
- writeConfig rename failure leaves no temp file behind
- writeConfig file mode 0o600 is preserved end-to-end through atomic rename
- 8 concurrent invocations produce one canonical state, zero orphans

## Security audit result

**APPROVED WITH OBSERVATIONS** (security-auditor). Atomicity invariant correctly implemented and pinned by tests with EXDEV failure injection + 8-way concurrency. Mode 0o600 preserved end-to-end via inode-preserving rename. 4 non-blocking observations tracked for v0.6+:

- **O-1**: \`fs.open(..., "wx", mode)\` (exclusive create) instead of \`fs.writeFile(..., { mode })\` — closes residual TOCTOU/symlink window for .gitignore (which lives outside the 0o700 .recall/ directory).
- **O-2**: orphan-temp recovery scan at bootstrap (\`<base>.tmp-*\` cleanup for dead PIDs).
- **O-3**: document the read-modify-write lost-update characteristic of writeConfig; consider an advisory lock if multiple writers become realistic.
- **O-4**: if durability across power-loss ever becomes a stated invariant, add fsync(tempPath) + fsync(parentDir) before/after rename.

## Test plan

- [x] \`npm run typecheck\` EXIT=0
- [x] \`npm run lint\` EXIT=0 (--max-warnings 0)
- [x] \`npm run lint:tests\` EXIT=0 (--max-warnings 0)
- [x] \`npm run validate:modules\` EXIT=0
- [x] \`npm run build\` EXIT=0
- [x] \`npm test\` EXIT=0 — **2574/2574 tests pass** (+10 vs baseline 2564)
- [x] CI required status check ci
- [x] SonarQube quality gate MCP Memoria Strict

## OWASP mapping

- **A04:2021 Insecure Design** — strengthened (atomicity invariant explicitly designed and pinned).
- **A05:2021 Security Misconfiguration** — closed (truncation risk on the privacy guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)