### PR TITLE
feat(mcp-server): cap stdin buffer to prevent DoS (W-3.1-SEC-M1)

### DIFF
--- a/code/src/bootstrap/composition-root.ts
+++ b/code/src/bootstrap/composition-root.ts
@@ -249,6 +249,36 @@ function tryReadWorkspaceId(workspaceRoot: string): WorkspaceId | null {
 }
 
 /**
+ * Resolves the optional override for the stdio frame-accumulator
+ * cap (W-3.1-SEC-M1).
+ *
+ * Reads `RECALL_MCP_MAX_BUFFER_BYTES`. When set to a positive
+ * integer, the bootstrap forwards the value into the container's
+ * `mcpStdioMaxBufferBytes` slot, which the MCP wiring forwards to
+ * `StdioJsonRpcServer` as `maxBufferBytes`. When the env var is
+ * absent OR malformed (non-numeric, non-positive, non-finite), the
+ * adapter falls back to its built-in default (`DEFAULT_MAX_BUFFER_BYTES`,
+ * 10 MiB).
+ *
+ * Returns `null` to communicate "no override" to the caller — that
+ * lets the caller spread the result conditionally and keep
+ * `exactOptionalPropertyTypes` happy.
+ *
+ * Malformed values (e.g. `"hello"`, `"-1"`) are silently ignored
+ * rather than thrown: the bootstrap path MUST stay robust against
+ * a misconfigured environment so the binary still starts and the
+ * canonical default applies. Operators see the failure in any
+ * subsequent overflow log payload, which records the active cap.
+ */
+function resolveMcpStdioMaxBufferBytes(): number | null {
+  const raw = process.env["RECALL_MCP_MAX_BUFFER_BYTES"];
+  if (raw === undefined || raw.length === 0) return null;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+/**
  * Sentinel returned when {@link resolvePackageVersion} cannot locate
  * or parse the bundled `package.json`. Returning a clearly-fake
  * version (rather than throwing) lets the bootstrap proceed — the
@@ -498,6 +528,7 @@ export async function bootstrapComposition(
     database = sqlite;
   }
 
+  const mcpStdioMaxBufferBytes = resolveMcpStdioMaxBufferBytes();
   const container = buildContainer({
     shared: {
       logger: {
@@ -513,6 +544,9 @@ export async function bootstrapComposition(
     schemaVersion: "1.0.0",
     serverInfo,
     ...(workspaceId !== null ? { workspaceId } : {}),
+    ...(mcpStdioMaxBufferBytes === null
+      ? {}
+      : { mcpStdioMaxBufferBytes }),
   });
 
   const shutdown = async (): Promise<void> => {

--- a/code/src/composition/container.ts
+++ b/code/src/composition/container.ts
@@ -200,6 +200,15 @@ export interface ContainerOptions {
    * fire against the placeholder workspace.
    */
   readonly workspaceId?: WorkspaceId;
+  /**
+   * Optional override for the stdio frame-accumulator cap (in JS
+   * string code units) applied by `StdioJsonRpcServer`
+   * (W-3.1-SEC-M1). The bootstrap entrypoint resolves the
+   * `RECALL_MCP_MAX_BUFFER_BYTES` env var and forwards the parsed
+   * value here. Unset → adapter falls back to
+   * `DEFAULT_MAX_BUFFER_BYTES` (10 MiB).
+   */
+  readonly mcpStdioMaxBufferBytes?: number;
 }
 
 /**
@@ -370,11 +379,21 @@ export function buildContainer(options: ContainerOptions): Container {
   };
 
   // Step 12 — mcp-server module.
+  // The stdio cap is forwarded only when explicitly supplied; the
+  // adapter applies its own default (`DEFAULT_MAX_BUFFER_BYTES`,
+  // 10 MiB) when the option is omitted. Spreading conditionally
+  // keeps `exactOptionalPropertyTypes` happy without smuggling an
+  // explicit `undefined` through the wiring boundary.
   const mcpServer = buildMcpServerWiring({
     logger,
     clock: shared.clock,
     facades: mcpServerFacades,
     serverInfo: options.serverInfo,
+    ...(options.mcpStdioMaxBufferBytes === undefined
+      ? {}
+      : {
+          stdioOptions: { maxBufferBytes: options.mcpStdioMaxBufferBytes },
+        }),
   });
   registerMvpTools({ registry: mcpServer.registry, clock: shared.clock });
 

--- a/code/src/composition/wiring/mcp-server-wiring.ts
+++ b/code/src/composition/wiring/mcp-server-wiring.ts
@@ -33,7 +33,10 @@ import {
   JsonRpcHandler,
   type ServerInfo,
 } from "../../modules/mcp-server/infrastructure/transport/json-rpc-handler.ts";
-import { StdioJsonRpcServer } from "../../modules/mcp-server/infrastructure/transport/stdio-json-rpc-server.ts";
+import {
+  StdioJsonRpcServer,
+  type StdioJsonRpcServerOptions,
+} from "../../modules/mcp-server/infrastructure/transport/stdio-json-rpc-server.ts";
 
 /**
  * Bag of mcp-server-side artefacts the bootstrap entrypoint owns:
@@ -69,6 +72,13 @@ export interface McpServerWiringOptions {
   readonly clock: Clock;
   readonly facades: McpServerFacadesBag;
   readonly serverInfo: ServerInfo;
+  /**
+   * Optional override for the stdio transport's frame-accumulator
+   * cap (W-3.1-SEC-M1). When unset, the adapter falls back to
+   * `DEFAULT_MAX_BUFFER_BYTES`. The composition root parses
+   * `RECALL_MCP_MAX_BUFFER_BYTES` and forwards the value here.
+   */
+  readonly stdioOptions?: StdioJsonRpcServerOptions;
 }
 
 /**
@@ -115,7 +125,13 @@ export function buildMcpServerWiring(
     readonly stdin: Readable;
     readonly stdout: Writable;
   }): StdioJsonRpcServer =>
-    new StdioJsonRpcServer(handler, input.stdin, input.stdout, options.logger);
+    new StdioJsonRpcServer(
+      handler,
+      input.stdin,
+      input.stdout,
+      options.logger,
+      options.stdioOptions,
+    );
 
   return {
     useCases,

--- a/code/src/modules/mcp-server/infrastructure/errors/buffer-overflow-error.ts
+++ b/code/src/modules/mcp-server/infrastructure/errors/buffer-overflow-error.ts
@@ -1,0 +1,94 @@
+import { McpServerInfrastructureError } from "./mcp-server-infrastructure-error.ts";
+
+/**
+ * Reserved server-error code (JSON-RPC 2.0 §5.1, range
+ * `-32099 .. -32000`). The wire spec does not define a standard
+ * code for "request too large"; this falls into the
+ * implementation-defined server-error band.
+ *
+ * The code surfaces in error logs (via the canonical
+ * `jsonRpcCode` field on `McpServerInfrastructureError`) but does
+ * NOT travel out as a wire response: a buffer overflow happens
+ * BEFORE a complete frame has been parsed, so the transport has
+ * nothing to correlate the error to. The policy is to close the
+ * transport (see {@link BufferOverflowError} docstring).
+ */
+const SERVER_ERROR = -32000;
+
+/**
+ * Structured side-channel for the cap and the size at which the
+ * cap was breached. Stored in {@link BufferOverflowError.details}
+ * and NOT concatenated into the public `message` per
+ * `W-3.5-SEC-L1`: numeric sizes are not sensitive themselves, but
+ * pino's redactor walks structured keys and not message content,
+ * so consistency keeps the redaction surface uniform across the
+ * error hierarchy (matches `DatabaseError.details.sqlLength`).
+ *
+ * Invariants:
+ * - `maxBufferBytes` is the configured cap (positive integer).
+ * - `bufferedBytes` is the accumulator size at the moment the
+ *   cap was breached (strictly greater than `maxBufferBytes`).
+ *
+ * `bytes` here means "UTF-16 code-unit count of the JavaScript
+ * string accumulator". For ASCII input this equals the UTF-8
+ * byte count; for non-ASCII it under-counts UTF-8 bytes, so the
+ * effective protection is at least as tight as the configured
+ * value when measured against an attacker streaming raw bytes.
+ */
+export interface BufferOverflowDetails {
+  readonly maxBufferBytes: number;
+  readonly bufferedBytes: number;
+}
+
+/**
+ * Raised by {@link StdioJsonRpcServer} when the line-delimited
+ * frame accumulator exceeds the configured cap WITHOUT a frame
+ * delimiter (`\n`) being seen.
+ *
+ * Threat model (W-3.1-SEC-M1):
+ * - An adversarial client streams bytes without ever emitting a
+ *   newline. The accumulator grows without bound, the process's
+ *   resident set climbs, and eventually the runtime is killed by
+ *   the OS or thrashes — a classic memory-exhaustion DoS.
+ * - The MVP shipping target (Claude Code as the only stdio peer)
+ *   does NOT exercise this vector, but the cap is defense in
+ *   depth: cheap to add, cheap to verify, and forward-compatible
+ *   with multi-tenant or third-party MCP integrations.
+ *
+ * Policy on overflow:
+ * - The transport is CLOSED. The `start()` promise rejects with
+ *   this error. The buffer is dropped to free memory. The client
+ *   must reconnect with a fresh stream.
+ * - Discarding the buffer and continuing was rejected: the
+ *   adversarial chunk likely contains the START of a legitimate
+ *   frame whose tail would arrive on the next read, and silently
+ *   discarding mid-frame would let later valid bytes parse as
+ *   garbage (cascading parse-error frames) instead of failing
+ *   loudly.
+ *
+ * Mapped onto the server-error band `-32000` (`SERVER_ERROR`).
+ * The error never leaves the process as a wire response: by
+ * construction the transport closes before another response is
+ * written. The numeric code is recorded for log routing only.
+ *
+ * Invariants:
+ * - `code` is the stable identifier
+ *   `mcp-server.transport.buffer-overflow`.
+ * - `jsonRpcCode` is `-32000` (reserved server-error band).
+ * - `details` is populated and frozen at construction time.
+ */
+export class BufferOverflowError extends McpServerInfrastructureError {
+  public readonly code = "mcp-server.transport.buffer-overflow";
+  public override readonly jsonRpcCode: number = SERVER_ERROR;
+  public readonly details: BufferOverflowDetails;
+
+  public constructor(details: BufferOverflowDetails) {
+    super(
+      "stdio frame accumulator exceeded the configured cap without a delimiter; closing transport",
+    );
+    this.details = Object.freeze({
+      maxBufferBytes: details.maxBufferBytes,
+      bufferedBytes: details.bufferedBytes,
+    });
+  }
+}

--- a/code/src/modules/mcp-server/infrastructure/index.ts
+++ b/code/src/modules/mcp-server/infrastructure/index.ts
@@ -25,7 +25,11 @@ export {
   type JsonRpcHandlerResult,
   type ServerInfo,
 } from "./transport/json-rpc-handler.ts";
-export { StdioJsonRpcServer } from "./transport/stdio-json-rpc-server.ts";
+export {
+  StdioJsonRpcServer,
+  DEFAULT_MAX_BUFFER_BYTES,
+  type StdioJsonRpcServerOptions,
+} from "./transport/stdio-json-rpc-server.ts";
 export {
   JSON_RPC_VERSION,
   isJsonRpcRequestShape,
@@ -52,3 +56,7 @@ export {
   type InvalidParamsIssue,
 } from "./errors/invalid-params-error.ts";
 export { InternalError } from "./errors/internal-error.ts";
+export {
+  BufferOverflowError,
+  type BufferOverflowDetails,
+} from "./errors/buffer-overflow-error.ts";

--- a/code/src/modules/mcp-server/infrastructure/transport/stdio-json-rpc-server.ts
+++ b/code/src/modules/mcp-server/infrastructure/transport/stdio-json-rpc-server.ts
@@ -1,10 +1,48 @@
 import type { Readable, Writable } from "node:stream";
 
 import type { Logger } from "../../../../shared/application/ports/logger.port.ts";
+import { BufferOverflowError } from "../errors/buffer-overflow-error.ts";
 import type {
   JsonRpcHandler,
   JsonRpcHandlerResult,
 } from "./json-rpc-handler.ts";
+
+/**
+ * Default cap on the size of the line-delimited frame accumulator,
+ * in JavaScript-string code units. Chosen at 10 MiB
+ * (`10 * 1024 * 1024 = 10_485_760`). Rationale:
+ * - Typical MCP JSON-RPC frames are well under 100 KB. Even a
+ *   `mem.recall` response with the maximum `top_k` and verbose
+ *   `summary`s sits under 1 MB once tokens are counted.
+ * - 10 MiB is roughly 100x the realistic worst-case frame, leaving
+ *   ample headroom for batched or unusually large `mem.remember`
+ *   payloads while still catching unbounded streams in the
+ *   second-to-low MB range.
+ * - Configurable per-instance via
+ *   {@link StdioJsonRpcServerOptions.maxBufferBytes} and overridable
+ *   at the composition root via the `RECALL_MCP_MAX_BUFFER_BYTES`
+ *   environment variable (see `composition-root.ts`).
+ */
+export const DEFAULT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Options for {@link StdioJsonRpcServer}. All fields are optional
+ * and have safe defaults; the bag exists so callers can opt in to
+ * one knob without spelling out the others.
+ */
+export interface StdioJsonRpcServerOptions {
+  /**
+   * Maximum size of the in-memory frame accumulator before a
+   * {@link BufferOverflowError} is raised and the transport is
+   * closed. Defaults to {@link DEFAULT_MAX_BUFFER_BYTES} (10 MiB).
+   *
+   * MUST be a positive finite integer; any other value is rejected
+   * at construction time. The unit is JavaScript-string code units
+   * (UTF-16); see the {@link BufferOverflowError} docstring for the
+   * mapping to UTF-8 bytes.
+   */
+  readonly maxBufferBytes?: number;
+}
 
 /**
  * Line-delimited JSON-RPC adapter for the MCP server.
@@ -29,9 +67,15 @@ import type {
  *   not a JSON-RPC response. Logging routes via the injected
  *   `Logger` (the canonical adapter is `PinoLogger`, which sends
  *   warn/error/fatal to stderr per the port contract).
- * - The adapter does NOT enforce a max frame size; the caller
- *   (Node.js stdin) buffers and chunks reasonably for the small
- *   request sizes typical of MCP traffic.
+ * - The adapter enforces a configurable cap on the size of the
+ *   frame accumulator (W-3.1-SEC-M1). When an adversarial client
+ *   streams bytes without a newline delimiter, the accumulator
+ *   would otherwise grow without bound — a memory-exhaustion DoS
+ *   vector. On overflow, the transport is closed and the
+ *   `start()` promise rejects with {@link BufferOverflowError};
+ *   the buffer is dropped to release memory. See the
+ *   `BufferOverflowError` docstring for the discard-vs-close
+ *   policy rationale.
  *
  * Concurrency:
  * - Frames are processed sequentially. The MVP does not need
@@ -41,28 +85,65 @@ import type {
 export class StdioJsonRpcServer {
   private buffer: string;
   private closed: boolean;
+  private readonly maxBufferBytes: number;
 
   public constructor(
     private readonly handler: JsonRpcHandler,
     private readonly stdin: Readable,
     private readonly stdout: Writable,
     private readonly logger: Logger,
+    options?: StdioJsonRpcServerOptions,
   ) {
     this.buffer = "";
     this.closed = false;
+    this.maxBufferBytes = resolveMaxBufferBytes(options?.maxBufferBytes);
   }
 
   /**
    * Starts reading frames from stdin. Returns a promise that
    * resolves when stdin closes (or rejects if a fatal write
-   * failure happens).
+   * failure or buffer overflow happens).
    */
   public async start(): Promise<void> {
     this.stdin.setEncoding("utf8");
     return new Promise<void>((resolve, reject) => {
+      const teardown = (): void => {
+        this.stdin.removeListener("data", onData);
+        this.stdin.removeListener("end", onEnd);
+        this.stdin.removeListener("error", onError);
+      };
       const onData = (chunk: string | Buffer): void => {
         const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
         this.buffer += text;
+        // Cap the accumulator BEFORE attempting to drain. If the
+        // newest chunk did not contain a delimiter and the running
+        // buffer is now over the cap, the client is either buggy or
+        // adversarial; either way, refuse to grow further.
+        if (
+          !this.buffer.includes("\n") &&
+          this.buffer.length > this.maxBufferBytes
+        ) {
+          const bufferedBytes = this.buffer.length;
+          // Drop the buffer NOW so the rejection path doesn't keep
+          // the oversized string alive on the closure.
+          this.buffer = "";
+          this.closed = true;
+          const overflow = new BufferOverflowError({
+            maxBufferBytes: this.maxBufferBytes,
+            bufferedBytes,
+          });
+          this.logger.warn(
+            {
+              err: serialiseError(overflow),
+              maxBufferBytes: this.maxBufferBytes,
+              bufferedBytes,
+            },
+            "stdio frame accumulator exceeded cap; closing transport",
+          );
+          teardown();
+          reject(overflow);
+          return;
+        }
         // Process every newline-terminated frame the buffer holds
         // right now. Anything trailing without a newline is left in
         // the buffer for the next chunk.
@@ -72,9 +153,7 @@ export class StdioJsonRpcServer {
             "stdio adapter frame loop failed",
           );
           this.closed = true;
-          this.stdin.removeListener("data", onData);
-          this.stdin.removeListener("end", onEnd);
-          this.stdin.removeListener("error", onError);
+          teardown();
           reject(toError(err));
         });
       };
@@ -96,9 +175,7 @@ export class StdioJsonRpcServer {
       };
       const onError = (err: unknown): void => {
         this.closed = true;
-        this.stdin.removeListener("data", onData);
-        this.stdin.removeListener("end", onEnd);
-        this.stdin.removeListener("error", onError);
+        teardown();
         reject(toError(err));
       };
       this.stdin.on("data", onData);
@@ -192,6 +269,24 @@ export class StdioJsonRpcServer {
       });
     });
   }
+}
+
+/**
+ * Validates the constructor-supplied cap and falls back to
+ * {@link DEFAULT_MAX_BUFFER_BYTES} when the option is absent. The
+ * function is total: any non-positive, non-finite, or non-integer
+ * supplied value is rejected with a `TypeError` at construction
+ * time so the failure surfaces immediately and not on the first
+ * adversarial chunk.
+ */
+function resolveMaxBufferBytes(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_MAX_BUFFER_BYTES;
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(
+      `StdioJsonRpcServer: maxBufferBytes must be a positive integer (received ${String(value)})`,
+    );
+  }
+  return value;
 }
 
 /**

--- a/code/tests/unit/mcp-server/infrastructure/stdio-json-rpc-server.test.ts
+++ b/code/tests/unit/mcp-server/infrastructure/stdio-json-rpc-server.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { PassThrough, Readable } from "node:stream";
 
-import { StdioJsonRpcServer } from "../../../../src/modules/mcp-server/infrastructure/transport/stdio-json-rpc-server.ts";
+import {
+  DEFAULT_MAX_BUFFER_BYTES,
+  StdioJsonRpcServer,
+  type StdioJsonRpcServerOptions,
+} from "../../../../src/modules/mcp-server/infrastructure/transport/stdio-json-rpc-server.ts";
+import { BufferOverflowError } from "../../../../src/modules/mcp-server/infrastructure/errors/buffer-overflow-error.ts";
 import type {
   JsonRpcHandler,
   JsonRpcHandlerResult,
@@ -85,12 +90,13 @@ interface ServerHarness {
 
 function makeHarness(
   responder: (raw: string) => JsonRpcHandlerResult,
+  options?: StdioJsonRpcServerOptions,
 ): ServerHarness {
   const stdin = new PassThrough();
   const stdout = new PassThrough();
   const logger = new RecordingLogger();
   const handler = new StubHandler(responder);
-  const server = new StdioJsonRpcServer(handler, stdin, stdout, logger);
+  const server = new StdioJsonRpcServer(handler, stdin, stdout, logger, options);
   const collector = collectStdoutFrames(stdout);
   return {
     stdin,
@@ -486,5 +492,231 @@ describe("StdioJsonRpcServer — Readable.from compatibility", () => {
     await server.start();
     const frames = collector.drain();
     expect(frames.length).toBe(2);
+  });
+});
+
+// ─── W-3.1-SEC-M1 — buffer-cap regression suite ─────────────────────────
+//
+// Each test asserts a behavioural property of the cap, not the
+// shape of an internal helper. The cap defends against unbounded
+// accumulator growth when an adversarial client streams bytes
+// without a frame delimiter.
+
+describe("StdioJsonRpcServer — buffer cap (W-3.1-SEC-M1)", () => {
+  it("rejects start() with BufferOverflowError when stdin streams more than the cap without a newline", async () => {
+    const cap = 1024;
+    const harness = makeHarness(() => makeSuccessFrame(0), {
+      maxBufferBytes: cap,
+    });
+    const startPromise = harness.server.start();
+    // Attach early so the rejection (which happens synchronously
+    // inside the data callback) doesn't surface as unhandled.
+    startPromise.catch(() => {
+      /* expected */
+    });
+    // Stream more than the cap with no `\n`. PassThrough preserves
+    // chunk boundaries so the adapter sees these as separate `data`
+    // events and the running buffer crosses the threshold on the
+    // second chunk.
+    harness.stdin.write("a".repeat(cap));
+    harness.stdin.write("b".repeat(64));
+    await expect(startPromise).rejects.toBeInstanceOf(BufferOverflowError);
+  });
+
+  it("populates BufferOverflowError.details with the cap and the buffered size (W-3.5-SEC-L1)", async () => {
+    const cap = 256;
+    const harness = makeHarness(() => makeSuccessFrame(0), {
+      maxBufferBytes: cap,
+    });
+    const startPromise = harness.server.start();
+    startPromise.catch(() => {
+      /* expected */
+    });
+    harness.stdin.write("x".repeat(cap + 64));
+    let captured: unknown = null;
+    try {
+      await startPromise;
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(BufferOverflowError);
+    if (captured instanceof BufferOverflowError) {
+      expect(captured.code).toBe("mcp-server.transport.buffer-overflow");
+      expect(captured.jsonRpcCode).toBe(-32000);
+      expect(captured.details.maxBufferBytes).toBe(cap);
+      expect(captured.details.bufferedBytes).toBeGreaterThan(cap);
+      // Sizes live in `details`, not `message` — assert the message
+      // does NOT contain the numeric values (W-3.5-SEC-L1).
+      expect(captured.message).not.toContain(String(cap));
+      expect(captured.message).not.toContain(
+        String(captured.details.bufferedBytes),
+      );
+    }
+  });
+
+  it("does NOT trigger overflow when a frame near the cap is delivered with a newline", async () => {
+    const cap = 4096;
+    // Build a frame whose payload PLUS the JSON-RPC envelope
+    // overhead leaves a comfortable margin under the cap; the
+    // frame ends with `\n` so the adapter drains it on receipt
+    // before the next chunk arrives. Any leftover chunk after
+    // drain is empty, so the cap check (which only fires when
+    // the running buffer has NO `\n` and is over the cap) does
+    // not trip.
+    const filler = "x".repeat(cap - 200);
+    const frame = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "tools/call",
+      id: 7,
+      params: { name: "mem.recall", arguments: { query: filler } },
+    });
+    expect(frame.length).toBeLessThanOrEqual(cap);
+    const harness = makeHarness(() => makeSuccessFrame(7), {
+      maxBufferBytes: cap,
+    });
+    const startPromise = harness.server.start();
+    harness.stdin.write(`${frame}\n`);
+    harness.stdin.end();
+    await startPromise;
+    expect(harness.handler.received.length).toBe(1);
+  });
+
+  it("respects an explicit maxBufferBytes lower than the default", async () => {
+    // The default is 10 MiB; a 512-byte cap must clearly trip on a
+    // 1 KB stream. This proves the constructor option flows through.
+    const harness = makeHarness(() => makeSuccessFrame(0), {
+      maxBufferBytes: 512,
+    });
+    const startPromise = harness.server.start();
+    startPromise.catch(() => {
+      /* expected */
+    });
+    harness.stdin.write("a".repeat(1024));
+    await expect(startPromise).rejects.toBeInstanceOf(BufferOverflowError);
+  });
+
+  it("exposes a default cap of 10 MiB", () => {
+    expect(DEFAULT_MAX_BUFFER_BYTES).toBe(10 * 1024 * 1024);
+  });
+
+  it("does NOT trigger overflow at the default cap when no option is supplied (cap unchanged)", async () => {
+    // Drive 1 KiB through the adapter without any option override
+    // and observe a clean round-trip — proves the default is well
+    // above realistic frame sizes.
+    const harness = makeHarness((raw) =>
+      makeSuccessFrame((JSON.parse(raw) as { id: number }).id),
+    );
+    const startPromise = harness.server.start();
+    const frame = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "x",
+      id: 1,
+      params: { payload: "x".repeat(1024) },
+    });
+    harness.stdin.write(`${frame}\n`);
+    harness.stdin.end();
+    await startPromise;
+    expect(harness.handler.received.length).toBe(1);
+  });
+
+  it("closes the transport (unbinds listeners) when overflow happens", async () => {
+    const cap = 256;
+    const harness = makeHarness(() => makeSuccessFrame(0), {
+      maxBufferBytes: cap,
+    });
+    const startPromise = harness.server.start();
+    startPromise.catch(() => {
+      /* expected */
+    });
+    harness.stdin.write("z".repeat(cap + 64));
+    await expect(startPromise).rejects.toBeInstanceOf(BufferOverflowError);
+    // After overflow, the adapter MUST have detached its listeners
+    // so a stale stdin event cannot drive further dispatches.
+    expect(harness.stdin.listenerCount("data")).toBe(0);
+    expect(harness.stdin.listenerCount("end")).toBe(0);
+    expect(harness.stdin.listenerCount("error")).toBe(0);
+  });
+
+  it("logs a warn entry on overflow with the cap and excess size (no buffer contents)", async () => {
+    const cap = 128;
+    const harness = makeHarness(() => makeSuccessFrame(0), {
+      maxBufferBytes: cap,
+    });
+    const startPromise = harness.server.start();
+    startPromise.catch(() => {
+      /* expected */
+    });
+    const adversarial = "secret-token-".repeat(64);
+    harness.stdin.write(adversarial);
+    try {
+      await startPromise;
+    } catch {
+      /* expected */
+    }
+    const warns = harness.logger.entries.filter((e) => e.level === "warn");
+    expect(warns.length).toBeGreaterThanOrEqual(1);
+    const payload = warns[0]?.payload;
+    expect(typeof payload).toBe("object");
+    if (typeof payload === "object" && payload !== null) {
+      const bag = payload as Record<string, unknown>;
+      expect(bag["maxBufferBytes"]).toBe(cap);
+      expect(typeof bag["bufferedBytes"]).toBe("number");
+      // The buffer's content MUST NOT have leaked into any logged
+      // field — defence against secrets accidentally streamed by a
+      // misbehaving client.
+      const serialised = JSON.stringify(bag);
+      expect(serialised).not.toContain("secret-token-");
+    }
+  });
+
+  it("rejects an invalid maxBufferBytes at construction time", () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const logger = new RecordingLogger();
+    const handler = new StubHandler(() => makeSuccessFrame(0));
+    expect(
+      () =>
+        new StdioJsonRpcServer(handler, stdin, stdout, logger, {
+          maxBufferBytes: 0,
+        }),
+    ).toThrow(TypeError);
+    expect(
+      () =>
+        new StdioJsonRpcServer(handler, stdin, stdout, logger, {
+          maxBufferBytes: -1,
+        }),
+    ).toThrow(TypeError);
+    expect(
+      () =>
+        new StdioJsonRpcServer(handler, stdin, stdout, logger, {
+          maxBufferBytes: 1.5,
+        }),
+    ).toThrow(TypeError);
+  });
+
+  it("processes a multi-chunk frame whose total stays under the cap", async () => {
+    // Defence against a false positive: a frame split across many
+    // chunks whose accumulated length is BELOW the cap must NOT
+    // trip overflow (the cap only applies when no `\n` is in the
+    // running buffer AND the buffer has crossed the cap).
+    const cap = 4096;
+    const harness = makeHarness((raw) =>
+      makeSuccessFrame((JSON.parse(raw) as { id: number }).id),
+      { maxBufferBytes: cap },
+    );
+    const startPromise = harness.server.start();
+    // Build a frame around 1 KiB across 4 writes, no newline until
+    // the last chunk.
+    const head = '{"jsonrpc":"2.0","method":"x","id":42,"params":{"q":"';
+    const body = "y".repeat(900);
+    const tail = '"}}';
+    harness.stdin.write(head);
+    harness.stdin.write(body.slice(0, 300));
+    harness.stdin.write(body.slice(300, 600));
+    harness.stdin.write(body.slice(600));
+    harness.stdin.write(`${tail}\n`);
+    harness.stdin.end();
+    await startPromise;
+    expect(harness.handler.received.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Fourth and final fix of the **v0.5 hardening cycle** (HANDOFF.md §6.21 roadmap row 4). Closes warning **W-3.1-SEC-M1**: \`StdioJsonRpcServer\` accumulator buffer had no upper bound. Adversarial peer streaming bytes without a delimiter could grow the buffer until OOM.

This PR adds a configurable cap with a sensible default (10 MiB ≈ 100x typical JSON-RPC payloads) and closes the transport when exceeded.

## What changed

### Code

- **NEW** \`code/src/modules/mcp-server/infrastructure/errors/buffer-overflow-error.ts\` (+94 LOC) — Typed error \`BufferOverflowError extends McpServerInfrastructureError\` with stable \`code: "mcp-server.transport.buffer-overflow"\`, \`jsonRpcCode: -32000\`, and \`details: { maxBufferBytes, bufferedBytes }\`. Sizes live in \`details\`, NOT in \`message\` (consistent with W-3.5-SEC-L1 from PR-3).
- \`stdio-json-rpc-server.ts\` (+109/-6) — Optional 5th constructor parameter \`options?: { maxBufferBytes?: number }\` with default \`DEFAULT_MAX_BUFFER_BYTES = 10 * 1024 * 1024\`. The \`onData\` callback checks **cumulative** buffer length (\`this.buffer.length\`) after each append and BEFORE delimiter scan. On overflow:
  1. Capture \`bufferedBytes\` for diagnostics.
  2. Set \`this.buffer = ""\` immediately to release memory.
  3. Set \`this.closed = true\`.
  4. Construct \`BufferOverflowError\`.
  5. Emit \`logger.warn\` with \`maxBufferBytes\` + \`bufferedBytes\` (no buffer content).
  6. Detach listeners (\`data | end | error\`).
  7. Reject the \`start()\` promise with the typed error.
- \`composition/wiring/mcp-server-wiring.ts\` (+18/-2) — \`McpServerWiringOptions.stdioOptions?\` threading.
- \`composition/container.ts\` (+19) — \`ContainerOptions.mcpStdioMaxBufferBytes?\` field; spread conditionally to honor \`exactOptionalPropertyTypes\`.
- \`bootstrap/composition-root.ts\` (+33/-1) — Env var resolver \`RECALL_MCP_MAX_BUFFER_BYTES\` (decimal integer; silently falls back to default if malformed).

### Tests (+10 tests, all VALOR)

1. Stream > cap without \`\\n\` → rejects with \`BufferOverflowError\`.
2. Error \`details\` carry \`maxBufferBytes\`/\`bufferedBytes\`; \`message\` does NOT contain sizes (W-3.5-SEC-L1 compliance).
3. Boundary: frame near cap WITH delimiter → no overflow, handler invoked.
4. Custom \`maxBufferBytes=512\` is respected.
5. \`DEFAULT_MAX_BUFFER_BYTES === 10 * 1024 * 1024\` (default exposed).
6. Default does not break realistic 1 KiB traffic.
7. After overflow: stdin listener counts (\`data | end | error\`) all return to 0.
8. Logger payload does NOT contain adversarial buffer content (\`secret-token-\` × 64).
9. Constructor validates \`maxBufferBytes\` (rejects 0, -1, 1.5).
10. Multi-chunk under cap (4× chunks ~256 B, no newline until last) → no false-positive overflow.

## Threshold rationale (10 MiB default)

- MCP frames typically <100 KB (e.g. \`mem.recall\` with \`top_k=50\` and verbose summaries stays under 1 MB).
- 10 MiB is ~100x worst realistic case — generous for batch operations, capping unbounded growth before low-MB adversarial pressure.
- No precedent in repo for a different value in this context.

## Transport closure decision

**CLOSE on overflow** (NOT discard+continue). Rationale:
- Discarding mid-frame leaves the next chunk without context: a legitimate frame's tail lands after the discard and parses as garbage, cascading parse errors that hide the actual problem.
- \`start()\` rejects → bootstrap entrypoint catches → logs fatal → exit 1.
- Client must reconnect with fresh stream (transport-fault-recovery semantics).

## Env var override

\`RECALL_MCP_MAX_BUFFER_BYTES\` (decimal positive integer). Resolution at \`composition-root.ts\`:

- Absent or empty → \`null\` (no override; default applies).
- Numeric positive integer → forwarded.
- Malformed (non-numeric, ≤0, non-finite) → silently \`null\` (default applies). Robustness over fail-fast: bootstrap should not block on misconfigured env.

Constructor option takes precedence (env only read in composition-root).

## Security audit result

**APPROVED WITH OBSERVATIONS** (security-auditor). DoS surface analysis confirms cumulative cap correctness; memory release ordering verified; transport closure clean; logger no-leak end-to-end pinned by tests; backward-compat preserved (5th constructor param optional; existing callers unchanged); no S7735 violations introduced.

5 non-blocking observations tracked for follow-up:

- **O-1 (MEDIUM)**: no rate-limit on reconnect-after-overflow. Acceptable for stdio CLI single-peer; document as known limitation in \`docs/11-seguridad-modos.md\` for v0.5+ multi-tenant scenarios.
- **O-2 (LOW)**: JSON parse-bomb (frame at exactly cap with pathological JSON) is OUT OF SCOPE — mitigation belongs to dispatcher/Zod validator. Document.
- **O-5 (LOW)**: add \`if (this.closed) return;\` guard at top of \`onData\` as defense-in-depth against late-tick callbacks. One-line follow-up.
- **O-7 (LOW)**: env var regex validation (\`/^\\d+$/\`) before \`parseInt\` so e.g. \`"1.5e7"\` does not silently become \`1\`.
- **O-8 (LOW)**: cap env-var-supplied value to absolute ceiling (e.g. 1 GiB) so an operator typo (\`10737418240000\` = 10 TB) cannot effectively disable protection.

## Test plan

- [x] \`npm run typecheck\` EXIT=0
- [x] \`npm run lint\` EXIT=0 (--max-warnings 0)
- [x] \`npm run lint:tests\` EXIT=0 (--max-warnings 0)
- [x] \`npm run validate:modules\` EXIT=0
- [x] \`npm run build\` EXIT=0
- [x] \`npm test\` EXIT=0 — **2588/2588 tests pass** (+10 vs baseline 2578)

## OWASP mapping

- **A04:2021 Insecure Design** — closed (DoS surface from unbounded accumulator).
- **A05:2021 Security Misconfiguration** — strengthened (env-driven cap with safe default).
- **A09:2021 Security Logging Failures** — confirmed clean (no buffer content in logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)