### PR TITLE
feat(crypto,encryption): tighten TypedArray buffer ownership for @types/node@25

### DIFF
--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
-        "@types/node": "^24.0.0",
+        "@types/node": "^25.7.0",
         "@vitest/coverage-istanbul": "^4.1.6",
         "@vitest/coverage-v8": "^4.1.6",
         "eslint": "^10.2.1",
@@ -1951,13 +1951,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.21.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6778,9 +6778,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/code/package.json
+++ b/code/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
-    "@types/node": "^24.0.0",
+    "@types/node": "^25.7.0",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@vitest/coverage-v8": "^4.1.6",
     "eslint": "^10.2.1",

--- a/code/src/modules/encryption/domain/value-objects/derived-key.ts
+++ b/code/src/modules/encryption/domain/value-objects/derived-key.ts
@@ -82,9 +82,13 @@ export class DerivedKey {
 
   /**
    * The ONLY supported way to access the wrapped bytes. See
-   * `MasterKey.withBytes` for the rationale.
+   * `MasterKey.withBytes` for the rationale and the
+   * `Uint8Array<ArrayBuffer>` callback-parameter typing
+   * justification.
    */
-  public withBytes<TResult>(callback: (bytes: Uint8Array) => TResult): TResult {
+  public withBytes<TResult>(
+    callback: (bytes: Uint8Array<ArrayBuffer>) => TResult,
+  ): TResult {
     const copy = new Uint8Array(this.bytes);
     return callback(copy);
   }

--- a/code/src/modules/encryption/domain/value-objects/master-key.ts
+++ b/code/src/modules/encryption/domain/value-objects/master-key.ts
@@ -113,8 +113,20 @@ export class MasterKey {
    * the callback (e.g. by capturing it in a closure assigned to an
    * outer variable). The convention is enforced by code review and
    * by lint rules in the secrets/security validators.
+   *
+   * Buffer ownership: the callback parameter is typed as
+   * `Uint8Array<ArrayBuffer>` (not the looser
+   * `Uint8Array<ArrayBufferLike>`) to document the runtime
+   * guarantee — `new Uint8Array(this.bytes)` always allocates an
+   * `ArrayBuffer`-backed view, never a `SharedArrayBuffer`-backed
+   * one. The tighter type lets downstream Web Crypto callsites
+   * (`subtle.importKey("raw", bytes, ...)`) consume the buffer
+   * without an explicit cast under `@types/node@25`'s stricter
+   * `BufferSource` definition.
    */
-  public withBytes<TResult>(callback: (bytes: Uint8Array) => TResult): TResult {
+  public withBytes<TResult>(
+    callback: (bytes: Uint8Array<ArrayBuffer>) => TResult,
+  ): TResult {
     const copy = new Uint8Array(this.bytes);
     return callback(copy);
   }

--- a/code/src/modules/encryption/domain/value-objects/salt-bytes.ts
+++ b/code/src/modules/encryption/domain/value-objects/salt-bytes.ts
@@ -88,7 +88,9 @@ export class SaltBytes {
    * codebase rule "secret material never leaves a VO via getter" is
    * easy to enforce when ALL crypto VOs follow it.
    */
-  public withBytes<TResult>(callback: (bytes: Uint8Array) => TResult): TResult {
+  public withBytes<TResult>(
+    callback: (bytes: Uint8Array<ArrayBuffer>) => TResult,
+  ): TResult {
     const copy = new Uint8Array(this.bytes);
     return callback(copy);
   }

--- a/code/src/modules/encryption/infrastructure/cipher/aes-gcm-envelope-cipher.ts
+++ b/code/src/modules/encryption/infrastructure/cipher/aes-gcm-envelope-cipher.ts
@@ -207,8 +207,14 @@ function getSubtle(): webcrypto.SubtleCrypto {
  * Generates a fresh 12-byte nonce from Node's CSPRNG. AES-GCM
  * security collapses on nonce reuse, so we use the platform's
  * canonical entropy source directly here.
+ *
+ * Return type is `Uint8Array<ArrayBuffer>` (not the looser
+ * `Uint8Array<ArrayBufferLike>`) to document that the helper
+ * always allocates a fresh `ArrayBuffer`-backed view — Web Crypto's
+ * `BufferSource` accepts only `<ArrayBuffer>` under
+ * `@types/node@25`'s stricter typings.
  */
-function generateNonce(): Uint8Array {
+function generateNonce(): Uint8Array<ArrayBuffer> {
   const buffer = new Uint8Array(AES_GCM_NONCE_LENGTH_BYTES);
   webcrypto.getRandomValues(buffer);
   return buffer;
@@ -223,7 +229,7 @@ function generateNonce(): Uint8Array {
  */
 async function importDerivedKey(
   subtle: webcrypto.SubtleCrypto,
-  bytes: Uint8Array,
+  bytes: Uint8Array<ArrayBuffer>,
   usage: webcrypto.KeyUsage,
 ): Promise<webcrypto.CryptoKey> {
   try {

--- a/code/src/modules/encryption/infrastructure/cipher/aes-gcm-key-validator.ts
+++ b/code/src/modules/encryption/infrastructure/cipher/aes-gcm-key-validator.ts
@@ -115,7 +115,7 @@ function getSubtle(): webcrypto.SubtleCrypto {
 
 async function importMasterKey(
   subtle: webcrypto.SubtleCrypto,
-  bytes: Uint8Array,
+  bytes: Uint8Array<ArrayBuffer>,
 ): Promise<webcrypto.CryptoKey> {
   try {
     return await subtle.importKey(

--- a/code/src/modules/encryption/infrastructure/cipher/aes-gcm-validator-encrypter.ts
+++ b/code/src/modules/encryption/infrastructure/cipher/aes-gcm-validator-encrypter.ts
@@ -115,7 +115,12 @@ function getSubtle(): webcrypto.SubtleCrypto {
   return webcrypto.subtle;
 }
 
-function generateNonce(): Uint8Array {
+/**
+ * Generates a fresh 12-byte nonce. See
+ * `aes-gcm-envelope-cipher.ts#generateNonce` for the
+ * `Uint8Array<ArrayBuffer>` return-typing rationale.
+ */
+function generateNonce(): Uint8Array<ArrayBuffer> {
   const buffer = new Uint8Array(AES_GCM_NONCE_LENGTH_BYTES);
   webcrypto.getRandomValues(buffer);
   return buffer;
@@ -123,7 +128,7 @@ function generateNonce(): Uint8Array {
 
 async function importMasterKey(
   subtle: webcrypto.SubtleCrypto,
-  bytes: Uint8Array,
+  bytes: Uint8Array<ArrayBuffer>,
 ): Promise<webcrypto.CryptoKey> {
   try {
     return await subtle.importKey(


### PR DESCRIPTION
## Summary

Closes the HANDOFF §7 Roadmap v0.5+ item #9 (originally tracked from [Phase-19 PR #60](https://github.com/NetziTech/recall/pull/60) which was closed with `@dependabot ignore this major version`).

`@types/node@25` narrows `BufferSource` so only `Uint8Array<ArrayBuffer>` satisfies it (the `SharedArrayBuffer` shape is excluded). Web Crypto callsites in the AES-GCM cipher / validator adapters fail to typecheck under the new types unless the buffer ownership invariant is documented in the API surface.

## Approach: type-signature tightening over `as` assertions

Rather than scatter `as Uint8Array<ArrayBuffer>` casts (as the original Phase-19 sketch predicted), this PR tightens the type signatures that **already hold the invariant at runtime**:

| File | Change |
|---|---|
| `master-key.ts`, `derived-key.ts`, `salt-bytes.ts` | `withBytes` callback parameter: `Uint8Array` → `Uint8Array<ArrayBuffer>`. The implementation already allocates a fresh `new Uint8Array(this.bytes)` defensive copy — only the declared type was looser than necessary. |
| `aes-gcm-envelope-cipher.ts`, `aes-gcm-validator-encrypter.ts` | `generateNonce()` return type: `Uint8Array` → `Uint8Array<ArrayBuffer>`. `new Uint8Array(N)` guarantees the ownership. |
| `aes-gcm-envelope-cipher.ts`, `aes-gcm-key-validator.ts`, `aes-gcm-validator-encrypter.ts` | `importDerivedKey`/`importMasterKey` `bytes` parameter: `Uint8Array` → `Uint8Array<ArrayBuffer>`. Lets `subtle.importKey("raw", bytes, ...)` resolve cleanly. |

**Zero `as` assertions introduced.** The tightening is strictly more type-safe and document-ative; downstream consumers of these helpers gain the same invariant for free.

## Diff

```
code/package.json                                        |  2 +-
code/package-lock.json                                   | 16 ++++++++--------
code/src/.../value-objects/{master,derived,salt}-key.ts  | 26 +++++++++++++++++++++++++
code/src/.../cipher/aes-gcm-{envelope,key-val,val-enc}.ts | 21 +++++++++++++++++---
8 files changed, 47 insertions(+), 18 deletions(-)
```

Net change: `@types/node` `^24` → `^25.7.0`. CI Node runtime stays at 24.15.0 LTS Krypton (runtime/types decoupled, see HANDOFF §6.24).

## Test plan

- [x] 5+1 EXIT=0 PASS (typecheck + lint + lint:tests + validate:modules + build)
- [x] 2625/2625 tests passing (unchanged vs PR #66 baseline)
- [x] Coverage Istanbul: unchanged (only typing changed, no new runtime branches)
- [x] `@types/node` lock at 25.7.0 (latest)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)