### PR TITLE
test(coverage): add VALOR tests to restore SonarQube gate 90→95

### DIFF
--- a/code/sonar-project.properties
+++ b/code/sonar-project.properties
@@ -37,8 +37,8 @@ sonar.sourceEncoding=UTF-8
 # Quality gate thresholds (definidos en el server SonarQube; documentados aqui
 # para referencia. Configurar el quality gate "MCP Memoria Strict" con:
 #
-#   Coverage on new code:        >= 90.0   (LOWERED from 95.0, see note)
-#   Coverage on overall code:    >= 90.0   (LOWERED from 95.0, see note)
+#   Coverage on new code:        >= 95.0   (RESTORED from 90.0, see note)
+#   Coverage on overall code:    >= 95.0   (RESTORED from 90.0, see note)
 #   Duplicated lines (%):        <= 3.0
 #   Maintainability rating:      A
 #   Reliability rating:          A
@@ -50,20 +50,22 @@ sonar.sourceEncoding=UTF-8
 #   Code smells (critical):      = 0
 #   Technical debt ratio:        <= 5.0%
 #
-# Note on the 95% → 90% coverage downgrade (this PR):
-# The previous 95% threshold was calibrated against `@vitest/coverage-v8@3.x`
-# which historically under-reported branches (optional chaining, nullish
-# coalescing, defensive checks). After migrating to coverage-istanbul@4.x
-# the honest branch coverage is ~89.6% and the SonarQube `coverage`
-# aggregate sits at ~95.17% — barely passing the 95% gate with no room
-# for iteration. Lowering to 90% gives ~5 points of buffer so routine
-# PRs that touch error handling / port adapters do not get blocked by
-# the gate.
+# Note on the 90% → 95% coverage restore (this PR, v0.5+ roadmap item):
+# Phase-20 lowered the gate to 90% after migrating from
+# `@vitest/coverage-v8@3.x` (which under-reported branches in optional
+# chaining, nullish coalescing, defensive checks) to
+# `@vitest/coverage-istanbul@4.x`. The honest baseline was ~89.6%
+# branches / 95.17% aggregate — barely above 95% with no room.
 #
-# Roadmap to restore 95% (v0.5+):
-#   - `json-encryption-config-repository.ts`: tests for 22 missed branches.
-#   - `json-memory-importer.ts` + `json-memory-exporter.ts`: 36 missed.
-#   - `get-context-bundle.use-case.ts`: 20 missed.
-#   - `node-workspace-filesystem.ts` + 3 sqlite repos: ~30 missed.
-#   - Goal: aggregate `coverage` ≥ 95.5% before restoring strict gate.
+# This PR adds VALOR-asserting tests across the four largest gap files
+# (json-memory-importer, json-memory-exporter, json-encryption-config-
+# repository, node-workspace-filesystem). The new aggregate coverage is
+# ~95.6%, giving ~0.6 pts of headroom over the restored 95% threshold.
+#
+# Going forward: routine PRs that touch error handling / port adapters
+# may briefly drop the aggregate below 95% by a few tenths. Before
+# merging such a PR, add 1-2 VALOR tests to the affected file. If the
+# drop is structural (provider counting model change again, etc.) and
+# not addressable by a targeted test, revisit this threshold via a
+# documented PR rather than silently relaxing it.
 # ============================================================================

--- a/code/tests/unit/encryption/infrastructure/json-encryption-config-repository.test.ts
+++ b/code/tests/unit/encryption/infrastructure/json-encryption-config-repository.test.ts
@@ -274,4 +274,226 @@ describe("JsonEncryptionConfigRepository", () => {
     expect(loaded2).not.toBeNull();
     expect(loaded2?.envelopeCount()).toBe(1);
   });
+
+  // Coverage focus: malformed inputs that exercise the
+  // ENCRYPTION_SLICE_SCHEMA / parseAlgorithm / parseKdfParams /
+  // parseValidatorBlob / parseEnvelope catch arms (lines 235, 269,
+  // 589, 612, 638, 686). Each writes a hand-crafted `.recall/config.json`
+  // with one field corrupted and asserts the repository raises
+  // `EncryptionConfigPersistenceError.malformed`.
+
+  const writeConfig = async (content: unknown): Promise<void> => {
+    const dir = path.join(workspaceRoot, ".recall");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "config.json"),
+      JSON.stringify(content, null, 2),
+      "utf8",
+    );
+  };
+
+  const validEnvelopeBlob = (): {
+    iv_b64: string;
+    ciphertext_b64: string;
+    tag_b64: string;
+  } => ({
+    iv_b64: Buffer.from(buf(12, 0xcd)).toString("base64"),
+    ciphertext_b64: Buffer.from(buf(32, 0xab)).toString("base64"),
+    tag_b64: Buffer.from(buf(16, 0xef)).toString("base64"),
+  });
+
+  const validKdfParams = (): {
+    memory_kib: number;
+    iterations: number;
+    parallelism: number;
+    salt_b64: string;
+  } => ({
+    memory_kib: 65536,
+    iterations: 3,
+    parallelism: 4,
+    salt_b64: Buffer.from(buf(16, 7)).toString("base64"),
+  });
+
+  const validSlice = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+    kdf: "argon2id",
+    kdf_params: validKdfParams(),
+    key_validator_blob_b64: {
+      iv_b64: Buffer.from(buf(12, 0x66)).toString("base64"),
+      ciphertext_b64: Buffer.from(buf(18, 0x55)).toString("base64"),
+      tag_b64: Buffer.from(buf(16, 0x77)).toString("base64"),
+    },
+    key_envelopes: [
+      {
+        id: KEY_ID,
+        created_at_ms: 1_700_000_000_000,
+        label: null,
+        kdf_params: validKdfParams(),
+        envelope: validEnvelopeBlob(),
+      },
+    ],
+    encryption_workspace_id: WS_ID,
+    encryption_created_at_ms: 1_700_000_000_000,
+    encryption_updated_at_ms: 1_700_000_000_000,
+    ...overrides,
+  });
+
+  const repoForWorkspace = (): JsonEncryptionConfigRepository =>
+    new JsonEncryptionConfigRepository({
+      workspaceRoot,
+      clock: new FakeClock({ initialMs: 1 }),
+      logger: new RecordingLogger(),
+    });
+
+  it("rejects slice with malformed kdf algorithm string", async () => {
+    await writeConfig(validSlice({ kdf: "not-a-real-algorithm" }));
+    await expect(
+      repoForWorkspace().findByWorkspace(WorkspaceId.from(WS_ID)),
+    ).rejects.toBeInstanceOf(EncryptionConfigPersistenceError);
+  });
+
+  it("rejects slice with malformed kdf_params (bad base64 salt)", async () => {
+    await writeConfig(
+      validSlice({
+        kdf_params: {
+          ...validKdfParams(),
+          salt_b64: "not!valid$base64",
+        },
+      }),
+    );
+    await expect(
+      repoForWorkspace().findByWorkspace(WorkspaceId.from(WS_ID)),
+    ).rejects.toBeInstanceOf(EncryptionConfigPersistenceError);
+  });
+
+  it("rejects slice with malformed validator blob (bad base64 ciphertext)", async () => {
+    await writeConfig(
+      validSlice({
+        key_validator_blob_b64: {
+          iv_b64: Buffer.from(buf(12, 0x66)).toString("base64"),
+          ciphertext_b64: "not_valid_base64=", // underscore is not standard alphabet
+          tag_b64: Buffer.from(buf(16, 0x77)).toString("base64"),
+        },
+      }),
+    );
+    await expect(
+      repoForWorkspace().findByWorkspace(WorkspaceId.from(WS_ID)),
+    ).rejects.toBeInstanceOf(EncryptionConfigPersistenceError);
+  });
+
+  it("rejects envelope with malformed inner ciphertext", async () => {
+    await writeConfig(
+      validSlice({
+        key_envelopes: [
+          {
+            id: KEY_ID,
+            created_at_ms: 1_700_000_000_000,
+            label: null,
+            kdf_params: validKdfParams(),
+            envelope: {
+              iv_b64: Buffer.from(buf(12, 0xcd)).toString("base64"),
+              ciphertext_b64: "ZZZ", // padding off, not a multiple of 4
+              tag_b64: Buffer.from(buf(16, 0xef)).toString("base64"),
+            },
+          },
+        ],
+      }),
+    );
+    await expect(
+      repoForWorkspace().findByWorkspace(WorkspaceId.from(WS_ID)),
+    ).rejects.toBeInstanceOf(EncryptionConfigPersistenceError);
+  });
+
+  it("rejects envelope blob with empty base64 string field", async () => {
+    await writeConfig(
+      validSlice({
+        key_envelopes: [
+          {
+            id: KEY_ID,
+            created_at_ms: 1_700_000_000_000,
+            label: null,
+            kdf_params: validKdfParams(),
+            envelope: {
+              iv_b64: "",
+              ciphertext_b64: Buffer.from(buf(32, 0xab)).toString("base64"),
+              tag_b64: Buffer.from(buf(16, 0xef)).toString("base64"),
+            },
+          },
+        ],
+      }),
+    );
+    await expect(
+      repoForWorkspace().findByWorkspace(WorkspaceId.from(WS_ID)),
+    ).rejects.toBeInstanceOf(EncryptionConfigPersistenceError);
+  });
+
+  it("rehydrates envelope label when present (non-null label branch)", async () => {
+    await writeConfig(
+      validSlice({
+        key_envelopes: [
+          {
+            id: KEY_ID,
+            created_at_ms: 1_700_000_000_000,
+            label: "primary-key",
+            kdf_params: validKdfParams(),
+            envelope: validEnvelopeBlob(),
+          },
+        ],
+      }),
+    );
+    const loaded = await repoForWorkspace().findByWorkspace(WorkspaceId.from(WS_ID));
+    expect(loaded).not.toBeNull();
+    expect(loaded?.envelopeCount()).toBe(1);
+    const envelope = loaded?.getEnvelopes()[0];
+    expect(envelope?.label?.asString()).toBe("primary-key");
+  });
+
+  it("delete is a no-op when config.json exists but has no encryption slice", async () => {
+    // Configure file with only workspace-owned keys; the encryption-
+    // owned key set never matches, so `removedAnything` stays false
+    // (line 357) and delete emits a `no-encryption-slice` log line.
+    const dir = path.join(workspaceRoot, ".recall");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "config.json"),
+      JSON.stringify({ workspace_id: WS_ID, mode: "shared" }, null, 2),
+      "utf8",
+    );
+    const repo = repoForWorkspace();
+    await expect(repo.delete(WorkspaceId.from(WS_ID))).resolves.toBeUndefined();
+    // File should still exist with the unrelated keys intact.
+    const after = JSON.parse(
+      await fs.readFile(path.join(dir, "config.json"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(after["workspace_id"]).toBe(WS_ID);
+    expect(after["mode"]).toBe("shared");
+    expect(after["key_envelopes"]).toBeUndefined();
+  });
+
+  it("delete is a no-op when config.json is not an object (string content)", async () => {
+    const dir = path.join(workspaceRoot, ".recall");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "config.json"), '"not-an-object"', "utf8");
+    const repo = repoForWorkspace();
+    await expect(repo.delete(WorkspaceId.from(WS_ID))).resolves.toBeUndefined();
+  });
+
+  // Coverage: `fromBase64` rejection paths (lines 707, 710, 717, 725).
+  // Each exercises one of the four early-failure branches:
+  // empty / bad alphabet / bad padding length / silent truncation
+  // detected via round-trip.
+  it("rejects base64 fields that decode to silent truncation", async () => {
+    // "===" reencodes to "" (silent truncation: input had 4 chars, output
+    // re-encodes to 0). This hits the round-trip check at line 725.
+    await writeConfig(
+      validSlice({
+        kdf_params: {
+          ...validKdfParams(),
+          salt_b64: "====", // 4 chars of pure padding → decodes to empty → re-encodes to ""
+        },
+      }),
+    );
+    await expect(
+      repoForWorkspace().findByWorkspace(WorkspaceId.from(WS_ID)),
+    ).rejects.toBeInstanceOf(EncryptionConfigPersistenceError);
+  });
 });

--- a/code/tests/unit/memory/infrastructure/json-memory-exporter.test.ts
+++ b/code/tests/unit/memory/infrastructure/json-memory-exporter.test.ts
@@ -169,4 +169,268 @@ describe("JsonMemoryExporter.serialise", () => {
       }),
     ).toThrow();
   });
+
+  // Coverage focus: every "non-null" arm of the per-kind serialisers
+  // (supersededBy, lastUsedMs, consolidatedInto, description,
+  // dueAt/completedAt, intent/outcome, endedAt/summary/nextSeed/
+  // resumedFrom). The aggregates here are constructed via `rehydrate`
+  // factories so we can pin every nullable field directly.
+  it("serialises every populated nullable field on the wire", async () => {
+    const { Turn } = await import(
+      "../../../../src/modules/memory/domain/aggregates/turn.ts"
+    );
+    const { DecisionStatus } = await import(
+      "../../../../src/modules/memory/domain/value-objects/decision-status.ts"
+    );
+    const { SupersededBy } = await import(
+      "../../../../src/modules/memory/domain/value-objects/superseded-by.ts"
+    );
+    const { LastUsed } = await import(
+      "../../../../src/modules/memory/domain/value-objects/last-used.ts"
+    );
+    const { UseCount } = await import(
+      "../../../../src/modules/memory/domain/value-objects/use-count.ts"
+    );
+    const { TaskStatus } = await import(
+      "../../../../src/modules/memory/domain/value-objects/task-status.ts"
+    );
+    const { TaskDescription } = await import(
+      "../../../../src/modules/memory/domain/value-objects/task-description.ts"
+    );
+    const { TurnId } = await import(
+      "../../../../src/modules/memory/domain/value-objects/turn-id.ts"
+    );
+    const { TurnSummary } = await import(
+      "../../../../src/modules/memory/domain/value-objects/turn-summary.ts"
+    );
+    const { TurnIntent } = await import(
+      "../../../../src/modules/memory/domain/value-objects/turn-intent.ts"
+    );
+    const { TurnOutcome } = await import(
+      "../../../../src/modules/memory/domain/value-objects/turn-outcome.ts"
+    );
+    const { FilesTouched } = await import(
+      "../../../../src/modules/memory/domain/value-objects/files-touched.ts"
+    );
+    const { LinkedDecisionIds } = await import(
+      "../../../../src/modules/memory/domain/value-objects/linked-decision-ids.ts"
+    );
+    const { LinkedLearningIds } = await import(
+      "../../../../src/modules/memory/domain/value-objects/linked-learning-ids.ts"
+    );
+    const { SessionIntent } = await import(
+      "../../../../src/modules/memory/domain/value-objects/session-intent.ts"
+    );
+    const { SessionSummary } = await import(
+      "../../../../src/modules/memory/domain/value-objects/session-summary.ts"
+    );
+    const { SessionNextSeed } = await import(
+      "../../../../src/modules/memory/domain/value-objects/session-next-seed.ts"
+    );
+    const { SessionMetadata } = await import(
+      "../../../../src/modules/memory/domain/value-objects/session-metadata.ts"
+    );
+    const { TurnsCount } = await import(
+      "../../../../src/modules/memory/domain/value-objects/turns-count.ts"
+    );
+
+    const ws = makeWorkspaceId();
+    const TS = makeTimestamp(ANCHOR_TIME_MS);
+    const TS_USE = makeTimestamp(ANCHOR_TIME_MS + 10_000);
+    const TS_END = makeTimestamp(ANCHOR_TIME_MS + 20_000);
+
+    const successorId = DecisionId.from("01952f3c-2222-7000-8000-d00000000099");
+    const decision = Decision.rehydrate({
+      id: DecisionId.from(FIXED_DECISION_UUID),
+      workspaceId: ws,
+      sessionId: null,
+      title: DecisionTitle.from("T"),
+      rationale: Rationale.from("R"),
+      content: DecisionContent.from("Body"),
+      tags: makeTags(["a"]),
+      status: DecisionStatus.superseded(),
+      supersededBy: SupersededBy.of(successorId),
+      confidence: Confidence.full(),
+      useCount: UseCount.of(2),
+      lastUsed: LastUsed.at(TS_USE),
+      scope: Scope.project(),
+      embeddingStatus: EmbeddingStatus.pending(),
+      createdAt: TS,
+      updatedAt: TS_USE,
+    });
+
+    const consolidationTarget = LearningId.from(
+      "01952f3c-2222-7000-8000-cccccccccc09",
+    );
+    const learning = Learning.rehydrate({
+      id: LearningId.from(FIXED_LEARNING_UUID),
+      workspaceId: ws,
+      text: LearningText.from("L"),
+      severity: LearningSeverity.warning(),
+      tags: makeTags(),
+      confidence: Confidence.full(),
+      useCount: UseCount.of(3),
+      lastUsed: LastUsed.at(TS_USE),
+      scope: Scope.project(),
+      embeddingStatus: EmbeddingStatus.pending(),
+      consolidatedInto: consolidationTarget,
+      createdAt: TS,
+      updatedAt: TS_USE,
+    });
+
+    const entity = Entity.rehydrate({
+      id: EntityId.from(FIXED_ENTITY_UUID),
+      workspaceId: ws,
+      name: EntityName.from("E"),
+      kind: EntityKind.classKind(),
+      description: EntityDescription.of("desc"),
+      tags: makeTags(),
+      confidence: Confidence.full(),
+      useCount: UseCount.of(1),
+      lastUsed: LastUsed.at(TS_USE),
+      scope: Scope.project(),
+      embeddingStatus: EmbeddingStatus.pending(),
+      createdAt: TS,
+      updatedAt: TS_USE,
+    });
+
+    const task = Task.rehydrate({
+      id: TaskId.from(FIXED_TASK_UUID),
+      workspaceId: ws,
+      sessionId: null,
+      title: TaskTitle.from("T"),
+      description: TaskDescription.from("populated"),
+      status: TaskStatus.done(),
+      priority: TaskPriority.high(),
+      tags: makeTags(),
+      dueAt: TS_USE,
+      createdAt: TS,
+      updatedAt: TS_USE,
+      completedAt: TS_END,
+    });
+
+    const sessionId = SessionId.from(FIXED_SESSION_UUID);
+    const previousSessionId = SessionId.from(
+      "01952f3c-2222-7000-8000-111111111199",
+    );
+    const session = Session.rehydrate({
+      id: sessionId,
+      workspaceId: ws,
+      startedAt: TS,
+      endedAt: TS_END,
+      lastActivityAt: TS_END,
+      idleTimeoutMs: 1_800_000,
+      intent: SessionIntent.from("intent-x"),
+      summary: SessionSummary.from("summary-y"),
+      nextSeed: SessionNextSeed.from("seed-z"),
+      resumedFrom: previousSessionId,
+      turnsCount: TurnsCount.of(1),
+      metadata: SessionMetadata.empty(),
+    });
+
+    const turn = Turn.rehydrate({
+      id: TurnId.from("01952f3c-2222-7000-8000-ffffffffff09"),
+      workspaceId: ws,
+      sessionId,
+      summary: TurnSummary.from("S"),
+      intent: TurnIntent.from("intent"),
+      outcome: TurnOutcome.from("outcome"),
+      filesTouched: FilesTouched.create(["a.ts"]),
+      linkedDecisions: LinkedDecisionIds.create([
+        DecisionId.from(FIXED_DECISION_UUID),
+      ]),
+      linkedLearnings: LinkedLearningIds.create([
+        LearningId.from(FIXED_LEARNING_UUID),
+      ]),
+      tags: makeTags(),
+      confidence: Confidence.full(),
+      useCount: UseCount.of(2),
+      lastUsed: LastUsed.at(TS_USE),
+      createdAt: TS,
+    });
+
+    const out = new JsonMemoryExporter().serialise({
+      ...emptySnapshot(),
+      decisions: [decision],
+      learnings: [learning],
+      entities: [entity],
+      tasks: [task],
+      turns: [turn],
+      sessions: [session],
+    });
+    const parsed = JSON.parse(out) as {
+      decisions: { supersededBy: string | null; lastUsedMs: number | null }[];
+      learnings: { consolidatedInto: string | null; lastUsedMs: number | null }[];
+      entities: { description: string | null; lastUsedMs: number | null }[];
+      tasks: { description: string | null; completedAtMs: number | null }[];
+      turns: {
+        intent: string | null;
+        outcome: string | null;
+        filesTouched: string[];
+        linkedDecisions: string[];
+        linkedLearnings: string[];
+        lastUsedMs: number | null;
+      }[];
+      sessions: {
+        endedAtMs: number | null;
+        intent: string | null;
+        summary: string | null;
+        nextSeed: string | null;
+        resumedFrom: string | null;
+      }[];
+    };
+
+    // Decision: supersededBy + lastUsedMs both non-null.
+    expect(parsed.decisions[0]?.supersededBy).toBe(
+      "01952f3c-2222-7000-8000-d00000000099",
+    );
+    expect(parsed.decisions[0]?.lastUsedMs).toBe(TS_USE.toEpochMs());
+
+    // Learning: consolidatedInto + lastUsedMs both non-null.
+    expect(parsed.learnings[0]?.consolidatedInto).toBe(
+      "01952f3c-2222-7000-8000-cccccccccc09",
+    );
+    expect(parsed.learnings[0]?.lastUsedMs).toBe(TS_USE.toEpochMs());
+
+    // Entity: lastUsedMs non-null.
+    expect(parsed.entities[0]?.lastUsedMs).toBe(TS_USE.toEpochMs());
+
+    // Task: description + completedAt both non-null.
+    expect(parsed.tasks[0]?.description).toBe("populated");
+    expect(parsed.tasks[0]?.completedAtMs).toBe(TS_END.toEpochMs());
+
+    // Turn: intent + outcome + non-empty linkedDecisions/linkedLearnings
+    //       + lastUsedMs all populated.
+    expect(parsed.turns[0]?.intent).toBe("intent");
+    expect(parsed.turns[0]?.outcome).toBe("outcome");
+    expect(parsed.turns[0]?.filesTouched.length).toBe(1);
+    expect(parsed.turns[0]?.linkedDecisions.length).toBe(1);
+    expect(parsed.turns[0]?.linkedLearnings.length).toBe(1);
+    expect(parsed.turns[0]?.lastUsedMs).toBe(TS_USE.toEpochMs());
+
+    // Session: endedAt + intent + summary + nextSeed + resumedFrom all
+    // populated.
+    expect(parsed.sessions[0]?.endedAtMs).toBe(TS_END.toEpochMs());
+    expect(parsed.sessions[0]?.intent).toBe("intent-x");
+    expect(parsed.sessions[0]?.summary).toBe("summary-y");
+    expect(parsed.sessions[0]?.nextSeed).toBe("seed-z");
+    expect(parsed.sessions[0]?.resumedFrom).toBe(
+      "01952f3c-2222-7000-8000-111111111199",
+    );
+  });
+
+  it("surfaces non-Error throwables with a generic message", () => {
+    const fakeDecision = {
+      getId: () => {
+        throw "not-an-error-object";
+      },
+    };
+    const exporter = new JsonMemoryExporter();
+    expect(() =>
+      exporter.serialise({
+        ...emptySnapshot(),
+        decisions: [fakeDecision as unknown as Decision],
+      }),
+    ).toThrow(/JSON serialisation failed/);
+  });
 });

--- a/code/tests/unit/memory/infrastructure/json-memory-importer.test.ts
+++ b/code/tests/unit/memory/infrastructure/json-memory-importer.test.ts
@@ -168,6 +168,267 @@ describe("JsonMemoryImporter.parse", () => {
     ).toThrow();
   });
 
+  // Coverage focus: exercise the "non-null" arm of every nullable
+  // ternary in the per-kind builders (lastUsedMs, supersededBy,
+  // consolidatedInto, description, dueAt, completedAt, intent, outcome,
+  // endedAt, summary, nextSeed, resumedFrom, filesTouched non-empty,
+  // linkedDecisions non-empty, linkedLearnings non-empty).
+  // The round-trip-everything test above exercises the "null/empty"
+  // arms; this one exercises the populated arms.
+  it("rehydrates every nullable field when present (non-null branches)", () => {
+    const ws = makeWorkspaceId();
+    const importer = new JsonMemoryImporter();
+    const envelope = {
+      schemaVersion: 1,
+      decisions: [
+        {
+          id: "01952f3c-2222-7000-8000-d00000000001",
+          title: "T1",
+          rationale: "R1",
+          content: "Body 1",
+          tags: ["t"],
+          status: "active",
+          supersededBy: "01952f3c-2222-7000-8000-d00000000002",
+          confidence: 1.0,
+          useCount: 5,
+          lastUsedMs: 1700000010000,
+          scope: { kind: "project", module: null },
+          embeddingStatus: "pending",
+          createdAtMs: 1700000000000,
+          updatedAtMs: 1700000010000,
+        },
+      ],
+      learnings: [
+        {
+          id: "01952f3c-2222-7000-8000-cccccccccc01",
+          text: "L1",
+          severity: "warning",
+          tags: ["t"],
+          confidence: 0.9,
+          useCount: 3,
+          lastUsedMs: 1700000020000,
+          scope: { kind: "project", module: null },
+          embeddingStatus: "pending",
+          consolidatedInto: "01952f3c-2222-7000-8000-cccccccccc02",
+          createdAtMs: 1700000000000,
+          updatedAtMs: 1700000020000,
+        },
+      ],
+      entities: [
+        {
+          id: "01952f3c-2222-7000-8000-eeeeeeeeee01",
+          name: "Service",
+          kind: "class",
+          description: "non-empty",
+          tags: [],
+          confidence: 1.0,
+          useCount: 2,
+          lastUsedMs: 1700000030000,
+          scope: { kind: "project", module: null },
+          embeddingStatus: "pending",
+          createdAtMs: 1700000000000,
+          updatedAtMs: 1700000030000,
+        },
+      ],
+      tasks: [
+        {
+          id: "01952f3c-2222-7000-8000-aaaaaaaaaa01",
+          title: "T-task",
+          description: "with-detail",
+          status: "todo",
+          priority: "high",
+          tags: [],
+          dueAtMs: 1700000086400000,
+          createdAtMs: 1700000000000,
+          updatedAtMs: 1700000040000,
+          completedAtMs: 1700000040000,
+        },
+      ],
+      turns: [
+        {
+          id: "01952f3c-2222-7000-8000-ffffffffff01",
+          sessionId: "01952f3c-2222-7000-8000-111111111101",
+          summary: "S",
+          intent: "intent-x",
+          outcome: "outcome-y",
+          filesTouched: ["a.ts", "b.ts"],
+          linkedDecisions: ["01952f3c-2222-7000-8000-d00000000001"],
+          linkedLearnings: ["01952f3c-2222-7000-8000-cccccccccc01"],
+          tags: [],
+          confidence: 1.0,
+          useCount: 1,
+          lastUsedMs: 1700000050000,
+          createdAtMs: 1700000000000,
+        },
+      ],
+      sessions: [
+        {
+          id: "01952f3c-2222-7000-8000-111111111101",
+          startedAtMs: 1700000000000,
+          endedAtMs: 1700000060000,
+          lastActivityAtMs: 1700000060000,
+          idleTimeoutMs: 1_800_000,
+          intent: "session-intent",
+          summary: "session-summary",
+          nextSeed: "seed-text",
+          resumedFrom: "01952f3c-2222-7000-8000-111111111102",
+          turnsCount: 1,
+          openQuestions: [{ text: "q?", askedAtMs: 1700000005000 }],
+        },
+      ],
+      relations: [],
+    };
+    const snap = importer.parse({ json: JSON.stringify(envelope), workspaceId: ws });
+
+    // Decision: content present, supersededBy non-null, lastUsedMs non-null
+    expect(snap.decisions.length).toBe(1);
+    const dec = snap.decisions[0]!;
+    expect(dec.getContent().toString()).toBe("Body 1");
+    expect(dec.getSupersededBy()?.decisionId.toString()).toBe(
+      "01952f3c-2222-7000-8000-d00000000002",
+    );
+    expect(dec.getLastUsed().kind).toBe("at");
+
+    // Learning: consolidatedInto non-null + lastUsedMs non-null
+    expect(snap.learnings.length).toBe(1);
+    const learn = snap.learnings[0]!;
+    expect(learn.getConsolidatedInto()?.toString()).toBe(
+      "01952f3c-2222-7000-8000-cccccccccc02",
+    );
+    expect(learn.getLastUsed().kind).toBe("at");
+
+    // Entity: non-empty description + lastUsedMs non-null
+    expect(snap.entities.length).toBe(1);
+    const ent = snap.entities[0]!;
+    expect(ent.getDescription().toValue()).toEqual({
+      kind: "known",
+      text: "non-empty",
+    });
+    expect(ent.getLastUsed().kind).toBe("at");
+
+    // Task: non-empty description + dueAt non-null + completedAt non-null
+    expect(snap.tasks.length).toBe(1);
+    const tsk = snap.tasks[0]!;
+    expect(tsk.getDescription()?.toString()).toBe("with-detail");
+    expect(tsk.getDueAt()).not.toBeNull();
+    expect(tsk.getCompletedAt()).not.toBeNull();
+
+    // Turn: intent + outcome + filesTouched non-empty + linkedDecisions
+    //       + linkedLearnings + lastUsedMs all populated.
+    expect(snap.turns.length).toBe(1);
+    const trn = snap.turns[0]!;
+    expect(trn.getIntent()?.toString()).toBe("intent-x");
+    expect(trn.getOutcome()?.toString()).toBe("outcome-y");
+    expect(trn.getFilesTouched().toArray().length).toBe(2);
+    expect(trn.getLinkedDecisions().toArray().length).toBe(1);
+    expect(trn.getLinkedLearnings().toArray().length).toBe(1);
+    expect(trn.getLastUsed().kind).toBe("at");
+
+    // Session: endedAt + intent + summary + nextSeed + resumedFrom all
+    // populated.
+    expect(snap.sessions.length).toBe(1);
+    const sess = snap.sessions[0]!;
+    expect(sess.getEndedAt()).not.toBeNull();
+    expect(sess.getIntent()?.toString()).toBe("session-intent");
+    expect(sess.getSummary()?.toString()).toBe("session-summary");
+    expect(sess.getNextSeed()?.toString()).toBe("seed-text");
+    expect(sess.getResumedFrom()?.toString()).toBe(
+      "01952f3c-2222-7000-8000-111111111102",
+    );
+    expect(sess.getMetadata().openQuestions.length).toBe(1);
+  });
+
+  // Coverage: explicit "empty description"/"missing content" branches.
+  // These differ from "null" via Zod schema (the wire allows null for
+  // description; the importer also coerces empty strings to null/unknown).
+  it("treats empty description strings and missing content as their null equivalents", () => {
+    const ws = makeWorkspaceId();
+    const importer = new JsonMemoryImporter();
+    const envelope = {
+      schemaVersion: 1,
+      decisions: [
+        {
+          // No `content` key → fall back to rationale (line 279).
+          id: "01952f3c-2222-7000-8000-d00000000003",
+          title: "T",
+          rationale: "fallback rationale",
+          tags: [],
+          status: "active",
+          supersededBy: null,
+          confidence: 1.0,
+          useCount: 0,
+          lastUsedMs: null,
+          scope: { kind: "project", module: null },
+          embeddingStatus: "pending",
+          createdAtMs: 1700000000000,
+          updatedAtMs: 1700000000000,
+        },
+      ],
+      learnings: [],
+      entities: [
+        {
+          id: "01952f3c-2222-7000-8000-eeeeeeeeee02",
+          name: "Empty",
+          kind: "class",
+          // Empty description string → coerced to unknown via line 329.
+          description: "",
+          tags: [],
+          confidence: 1.0,
+          useCount: 0,
+          lastUsedMs: null,
+          scope: { kind: "project", module: null },
+          embeddingStatus: "pending",
+          createdAtMs: 1700000000000,
+          updatedAtMs: 1700000000000,
+        },
+      ],
+      tasks: [
+        {
+          id: "01952f3c-2222-7000-8000-aaaaaaaaaa02",
+          title: "T",
+          // Empty description string → coerced to null via line 362.
+          description: "",
+          status: "todo",
+          priority: "high",
+          tags: [],
+          dueAtMs: null,
+          createdAtMs: 1700000000000,
+          updatedAtMs: 1700000000000,
+          completedAtMs: null,
+        },
+      ],
+      turns: [],
+      sessions: [],
+      relations: [],
+    };
+    const snap = importer.parse({ json: JSON.stringify(envelope), workspaceId: ws });
+    expect(snap.decisions[0]!.getContent().toString()).toBe("fallback rationale");
+    expect(snap.entities[0]!.getDescription().toValue()).toEqual({
+      kind: "unknown",
+      text: null,
+    });
+    expect(snap.tasks[0]!.getDescription()).toBeNull();
+  });
+
+  it("surfaces non-Error throwables from JSON.parse with a generic message", () => {
+    const importer = new JsonMemoryImporter();
+    // JSON.parse always throws a SyntaxError (which IS an Error), so we
+    // patch JSON.parse to throw a non-Error value to exercise the
+    // `cause instanceof Error ? ... : "unknown"` false branch at
+    // line 218. The patch is scoped to a single call via a restore.
+    const orig = JSON.parse;
+    JSON.parse = (() => {
+      throw "not-an-error-object";
+    }) as typeof JSON.parse;
+    try {
+      expect(() =>
+        importer.parse({ json: "{}", workspaceId: makeWorkspaceId() }),
+      ).toThrow(/unknown/);
+    } finally {
+      JSON.parse = orig;
+    }
+  });
+
   it("round-trips every kind via exporter+importer", async () => {
     const ws = makeWorkspaceId();
     const { Learning } = await import(

--- a/code/tests/unit/workspace/infrastructure/filesystem/node-workspace-filesystem.test.ts
+++ b/code/tests/unit/workspace/infrastructure/filesystem/node-workspace-filesystem.test.ts
@@ -690,3 +690,120 @@ describe("NodeWorkspaceFilesystem.ensureGitignore — atomic write contract (W-3
     expect(tmpLeftovers).toEqual([]);
   });
 });
+
+// Coverage focus: the defensive guards in `removeWorkspaceDirectory`
+// (lines 245 and 253) reject paths that do not end with the canonical
+// `.recall` segment or that contain a NUL byte. These branches are
+// otherwise unreachable through the public API (every callsite goes
+// through `workspaceDirPath` first, which always produces a canonical
+// suffix) so the only way to exercise them is via a stub that returns
+// a hand-crafted path.
+describe("NodeWorkspaceFilesystem.removeWorkspaceDirectory — defensive guards", () => {
+  it("happy path: removes the .recall directory and its contents", async () => {
+    await fsAdapter.createWorkspaceDirectory(ctx.rootPath);
+    await fsAdapter.removeWorkspaceDirectory(ctx.rootPath);
+    const after = await fs
+      .stat(path.join(ctx.tmpDir, ".recall"))
+      .catch((err: unknown) => err);
+    expect(after).toBeInstanceOf(Error);
+  });
+
+  it("wraps rm errors as directoryRemoveFailed", async () => {
+    // Build a workspace, then make the .recall directory unremovable by
+    // chmodding the PARENT to read-only. rm reports the failure.
+    await fsAdapter.createWorkspaceDirectory(ctx.rootPath);
+    const parentDir = ctx.tmpDir;
+    if (process.platform !== "win32") {
+      await fs.chmod(parentDir, 0o500);
+      try {
+        await expect(
+          fsAdapter.removeWorkspaceDirectory(ctx.rootPath),
+        ).rejects.toBeInstanceOf(WorkspaceInfrastructureError);
+      } finally {
+        await fs.chmod(parentDir, 0o700);
+      }
+    }
+  });
+
+  it("rejects a non-canonical path produced by a buggy workspaceDirPath stub", () => {
+    // Spy on the private static workspaceDirPath to make it return a
+    // path that does NOT end with the canonical `.recall` segment.
+    const stub = vi
+      .spyOn(
+        NodeWorkspaceFilesystem as unknown as {
+          workspaceDirPath: (p: WorkspacePath) => string;
+        },
+        "workspaceDirPath",
+      )
+      .mockReturnValue("/tmp/not-canonical");
+    try {
+      return expect(
+        fsAdapter.removeWorkspaceDirectory(ctx.rootPath),
+      ).rejects.toBeInstanceOf(WorkspaceInfrastructureError);
+    } finally {
+      stub.mockRestore();
+    }
+  });
+
+  it("rejects a path containing a NUL byte produced by a buggy workspaceDirPath stub", () => {
+    const stub = vi
+      .spyOn(
+        NodeWorkspaceFilesystem as unknown as {
+          workspaceDirPath: (p: WorkspacePath) => string;
+        },
+        "workspaceDirPath",
+      )
+      .mockReturnValue("/tmp/has\0null/.recall");
+    try {
+      return expect(
+        fsAdapter.removeWorkspaceDirectory(ctx.rootPath),
+      ).rejects.toBeInstanceOf(WorkspaceInfrastructureError);
+    } finally {
+      stub.mockRestore();
+    }
+  });
+});
+
+// Coverage focus: `withGitignoreEntry`'s "already ends with \n" branch
+// (line 444) which short-circuits the newline-normalisation. The
+// existing private-mode tests seed with content ending in `\n` so this
+// branch IS reached, but the assertion on it is implicit; pin it
+// explicitly via byte-for-byte content checks.
+describe("NodeWorkspaceFilesystem.ensureGitignore — normalisation invariants", () => {
+  it("private: preserves \\n-terminated existing content without doubling the newline", async () => {
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    await fs.writeFile(gitignorePath, "foo\n", "utf8");
+    await fsAdapter.ensureGitignore(ctx.rootPath, WorkspaceMode.privateMode());
+    const after = await fs.readFile(gitignorePath, "utf8");
+    expect(after).toBe("foo\n.recall/\n");
+  });
+
+  it("private: adds the missing trailing newline before appending the entry", async () => {
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    await fs.writeFile(gitignorePath, "foo", "utf8"); // no trailing newline
+    await fsAdapter.ensureGitignore(ctx.rootPath, WorkspaceMode.privateMode());
+    const after = await fs.readFile(gitignorePath, "utf8");
+    expect(after).toBe("foo\n.recall/\n");
+  });
+
+  it("shared: removes both the canonical `.recall/` line AND the bare `.recall` directory variant", async () => {
+    // Cover the `withoutGitignoreEntry` branch at line 456 that filters
+    // the bare `.recall` directory name (vs the canonical `.recall/`).
+    const gitignorePath = path.join(ctx.tmpDir, ".gitignore");
+    await fs.writeFile(
+      gitignorePath,
+      "node_modules\n.recall\nbuild/\n",
+      "utf8",
+    );
+    await fsAdapter.ensureGitignore(ctx.rootPath, WorkspaceMode.sharedMode());
+    const after = await fs.readFile(gitignorePath, "utf8").catch(() => null);
+    if (after !== null) {
+      expect(after).not.toContain(".recall\n");
+    } else {
+      // The implementation may also unlink the file if it ends up empty.
+      // Both outcomes are valid; the contract is "no `.recall` entry
+      // remains".
+      expect(after).toBeNull();
+    }
+  });
+});

--- a/code/vitest.config.ts
+++ b/code/vitest.config.ts
@@ -123,17 +123,18 @@ export default defineConfig({
         ? undefined
         : {
             // Local thresholds calibrated to the Istanbul provider
-            // baseline post Refactor A + Fase B tests (vitest 4.x).
-            // Istanbul counts optional-chain / nullish-coalesce branches
-            // that coverage-v8 v3 historically under-reported; the
-            // honest line/branch ratios under the new measurement are
-            // what the SonarQube agreggate metric `coverage` consumes
+            // baseline post Refactor A + Fase B tests + W-3.5-coverage
+            // restore PR (vitest 4.x). Istanbul counts optional-chain /
+            // nullish-coalesce branches that coverage-v8 v3 historically
+            // under-reported; the honest line/branch ratios are what
+            // the SonarQube agreggate metric `coverage` consumes
             // (lines + conditions weighted). The composite value the
-            // SonarQube quality gate evaluates is ~95.2%, which is
-            // above the strict gate threshold of 95.
-            lines: 95,
-            branches: 88,
-            functions: 95,
+            // SonarQube quality gate evaluates is ~95.6%, which is
+            // above the strict gate threshold of 95 (restored from
+            // the 90% temporary gate set in Phase-20).
+            lines: 96,
+            branches: 89,
+            functions: 96,
             statements: 95,
             "src/**/domain/**": {
               lines: 99,
@@ -149,7 +150,7 @@ export default defineConfig({
             },
             "src/**/infrastructure/**": {
               lines: 90,
-              branches: 82,
+              branches: 83,
               functions: 90,
               statements: 90,
             },


### PR DESCRIPTION
## Summary

Closes the HANDOFF §6.25 Phase-20 follow-up item #11 ("restore SonarQube gate 90→95 when aggregate coverage real ≥ 95.5%"). Mirrors the per-file roadmap published in `sonar-project.properties`.

Phase-20 lowered the gate to 90% as a pragmatic response to the `@vitest/coverage-v8@3.x` → `@vitest/coverage-istanbul@4.x` migration which revealed the v3 baseline was inflated by ~3-7 points across optional-chain / nullish-coalesce / defensive-check branches. This PR delivers the real VALOR tests that close the gap, plus restores the gate.

## Tests added (+21 net)

| File | Tests added | Branches targeted |
|---|---:|---|
| `json-memory-importer.test.ts` | +3 | Every non-null nullable arm + non-Error JSON.parse throw |
| `json-memory-exporter.test.ts` | +2 | Every populated nullable serialiser arm + non-Error throw |
| `json-encryption-config-repository.test.ts` | +9 | parseAlgorithm / parseKdfParams / parseValidatorBlob / parseEnvelope catch arms + label non-null + delete idempotency + base64 silent truncation |
| `node-workspace-filesystem.test.ts` | +7 | `removeWorkspaceDirectory` defensive guards + gitignore normalisation branches |

Style follows the project's VALUES-not-SHAPE rule: each test asserts the *behavioral* output (e.g. `expect(dec.getSupersededBy()?.decisionId.toString()).toBe("...")`) rather than just `hit-counting` a branch.

## Coverage Istanbul delta (vs Phase-20 baseline 96.5 / 89.6 / 98.32 / 97.8)

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Statements | 96.5% | 96.7% | +0.20 |
| Branches | 89.6% | 90.57% | **+0.97** |
| Functions | 98.32% | 98.51% | +0.19 |
| Lines | 97.8% | 98.00% | +0.20 |

**SonarQube aggregate (lines + branches weighted): 95.17% → ~95.62%** — ~0.6 pt margin over the restored 95.0 threshold.

## Server-side action required after merge

The actual SonarQube gate lives on the server: https://sonar.netzi.dev → Quality Gates → `MCP Memoria Strict`. After merging this PR you must:

1. Flip `Coverage on new code: >= 90.0` → `>= 95.0`.
2. Flip `Coverage on overall code: >= 90.0` → `>= 95.0`.

CI verification on this PR will run against whichever threshold is currently active in the server.

## Test plan

- [x] 5+1 EXIT=0 PASS (typecheck + lint + lint:tests + validate:modules + build)
- [x] 2646/2646 tests passing (+21 vs PR #67 baseline 2625)
- [x] Local Vitest thresholds tightened to the new baseline (96/89/96/95)
- [x] `sonar-project.properties` doc reflects the restored 95% gate + maintenance instructions

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)