### PR TITLE
docs(curator): fix JSDoc drift in MemoryEntryWriter port

### DIFF
--- a/code/src/modules/curator/application/ports/out/memory-entry-writer.port.ts
+++ b/code/src/modules/curator/application/ports/out/memory-entry-writer.port.ts
@@ -11,9 +11,16 @@ import type { MemoryEntryKind } from "../../../domain/value-objects/memory-entry
  * kind-specific repository directly from `memory/domain`) for two
  * reasons:
  *
- * 1. ISP: the curator only needs three operations
- *    (`applyDecay`, `markPruned`, `tagAsStale`); a single narrow
- *    port keeps the test surface small.
+ * 1. ISP: the curator's mutation surface clusters into three
+ *    operation families (decay, prune, tag-as-stale), each with a
+ *    singular variant for ad-hoc calls and a batch variant for the
+ *    curator's bulk passes (`applyDecay` / `applyDecayBatch`,
+ *    `markPruned` / `markPrunedBatch`, `tagEntityAsStale`). Five
+ *    methods total, sharing the same dispatch semantics over
+ *    `MemoryEntryKind`, kept in a single narrow port because every
+ *    caller (the curator's prune / decay / self-heal use cases) is
+ *    in the same bounded context and the test surface remains
+ *    small. A sixth operation family would warrant segmentation.
  * 2. The implementation is a single SQLite-backed adapter
  *    (`SqliteMemoryEntryWriter` in
  *    `modules/curator/infrastructure/persistence/`). The adapter


### PR DESCRIPTION
## Summary

Doc-only fix. The port's class JSDoc claimed "three operations" but the interface declares five since `applyDecayBatch` landed in Phase 5 and `markPrunedBatch` landed in [#69](https://github.com/NetziTech/recall/pull/69).

Surfaced by the `solid-validator` architectural audit run today over the 4 PRs mergeados (W-3.5-SEC-L2, @types/node@25, coverage restore, markPrunedBatch). The validator otherwise reported APROBADO on all of them.

## Test plan

- [x] typecheck + lint PASS (doc-only change, no behaviour modified)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)