### PR TITLE
feat(shared): add secureZero helper (ADR-005 Q1+Q5 prereq)

### DIFF
--- a/code/src/shared/infrastructure/crypto/secure-zero.ts
+++ b/code/src/shared/infrastructure/crypto/secure-zero.ts
@@ -1,0 +1,46 @@
+/**
+ * Best-effort zeroisation of a {@link Buffer} containing sensitive
+ * material (passphrases, derived keys, decrypted envelope contents).
+ *
+ * Overwrites every byte of `buffer` with `0x00` in place via
+ * `Buffer.fill(0)`. The function returns nothing and never throws on
+ * empty or already-zero buffers.
+ *
+ * @remarks
+ * **Best-effort, not a post-process-exit guarantee.** Node's V8 runtime
+ * is free to copy bytes outside the original allocation while the
+ * caller holds the buffer:
+ *
+ * - `Buffer.from(string)` interns the source string in V8's heap. The
+ *   string copy survives any later `fill(0)` on the resulting buffer.
+ * - `Buffer.alloc(N)` / `Buffer.allocUnsafe(N)` carve slices off a
+ *   shared internal pool (`Buffer.poolSize`, default 8 KiB). Other
+ *   slices of the same pool may legitimately survive past the lifetime
+ *   of the buffer we zeroed.
+ * - The OS may have paged the memory to swap or hibernation before we
+ *   reach this call. Zeroing the in-RAM copy does not erase swap.
+ *
+ * **Caller responsibility.** To keep zeroisation meaningful, the upstream
+ * caller (the code that first materialises the secret in memory) MUST
+ * allocate the buffer with `Buffer.allocUnsafeSlow(N)`. `allocUnsafeSlow`
+ * bypasses the shared pool, so the only place those bytes live is inside
+ * the buffer we hand to `secureZero`. Avoid `Buffer.from("...")` on a
+ * passphrase string for the same reason.
+ *
+ * This helper does NOT verify the allocation strategy of its argument;
+ * doing so is impossible at runtime. It simply guarantees the bytes of
+ * the buffer it receives are clobbered before the reference is dropped.
+ *
+ * @param buffer - The buffer to overwrite. May be empty. Must not be
+ *   `null`/`undefined` (TypeScript enforces this at compile time).
+ *
+ * @see `docs/11-seguridad-modos.md` §3 — key lifetime and zeroisation
+ *   policy across the three operating modes.
+ * @see `docs/12-lineamientos-arquitectura.md` §1.5.5 (Q1 paso 4 + Q5
+ *   paso 5) — ADR-005 iteration 2 mandates this helper as the single
+ *   zero-fill primitive shared across CLI prompts and encryption
+ *   adapters.
+ */
+export function secureZero(buffer: Buffer): void {
+  buffer.fill(0);
+}

--- a/code/src/shared/infrastructure/index.ts
+++ b/code/src/shared/infrastructure/index.ts
@@ -48,6 +48,8 @@ export { UuidV7IdGenerator } from "./id-generator/uuid-v7-id-generator.ts";
 export { FakeIdGenerator } from "./id-generator/fake-id-generator.ts";
 export type { FakeIdGeneratorOptions } from "./id-generator/fake-id-generator.ts";
 
+export { secureZero } from "./crypto/secure-zero.ts";
+
 export { InfrastructureError } from "./errors/infrastructure-error.ts";
 export { DatabaseError } from "./errors/database-error.ts";
 export type { DatabaseErrorCode } from "./errors/database-error.ts";

--- a/code/tests/unit/shared/infrastructure/crypto/secure-zero.test.ts
+++ b/code/tests/unit/shared/infrastructure/crypto/secure-zero.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+
+import { secureZero } from "../../../../../src/shared/infrastructure/crypto/secure-zero.ts";
+
+describe("secureZero", () => {
+  it("fills all bytes of a populated buffer with zero", () => {
+    const buf = Buffer.alloc(32, 0xff);
+    expect(buf.every((byte) => byte === 0xff)).toBe(true);
+
+    secureZero(buf);
+
+    expect(buf).toHaveLength(32);
+    expect(buf.every((byte) => byte === 0x00)).toBe(true);
+  });
+
+  it("handles empty buffer (length 0) without throwing", () => {
+    const buf = Buffer.alloc(0);
+
+    expect(() => secureZero(buf)).not.toThrow();
+    expect(buf).toHaveLength(0);
+  });
+
+  it("handles already-zero buffer idempotently", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.every((byte) => byte === 0x00)).toBe(true);
+
+    secureZero(buf);
+
+    expect(buf).toHaveLength(16);
+    expect(buf.every((byte) => byte === 0x00)).toBe(true);
+  });
+
+  it("handles small buffer (length 1) correctly", () => {
+    const buf = Buffer.from([0xaa]);
+    expect(buf[0]).toBe(0xaa);
+
+    secureZero(buf);
+
+    expect(buf).toHaveLength(1);
+    expect(buf[0]).toBe(0x00);
+  });
+
+  it("handles boundary buffer (length 256, mixed values)", () => {
+    const buf = Buffer.alloc(256);
+    for (let i = 0; i < buf.length; i += 1) {
+      buf[i] = i & 0xff;
+    }
+    expect(buf[1]).toBe(0x01);
+    expect(buf[255]).toBe(0xff);
+
+    secureZero(buf);
+
+    expect(buf).toHaveLength(256);
+    for (let i = 0; i < buf.length; i += 1) {
+      expect(buf[i]).toBe(0x00);
+    }
+  });
+
+  it("works with Buffer.allocUnsafeSlow (the recommended caller pattern)", () => {
+    const buf = Buffer.allocUnsafeSlow(64);
+    buf.fill(0xff);
+    expect(buf.every((byte) => byte === 0xff)).toBe(true);
+
+    secureZero(buf);
+
+    expect(buf).toHaveLength(64);
+    expect(buf.every((byte) => byte === 0x00)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Prerequisito unico de codigo para iteracion 2 ADR-005 (multi-key envelope flow, Phase-22 ACCEPTED en PR #72).

- **`code/src/shared/infrastructure/crypto/secure-zero.ts`** — helper publico `secureZero(buffer: Buffer): void`. Sobreescribe todos los bytes con `0x00` via `buffer.fill(0)`. JSDoc documenta caveat best-effort (V8 string interning, pool sharing, swap fuera de scope) + responsabilidad del caller de usar `Buffer.allocUnsafeSlow(N)`.
- **`code/src/shared/infrastructure/index.ts`** — re-export en el barrel (grupo `crypto` antes de `errors`).
- **`code/tests/unit/shared/infrastructure/crypto/secure-zero.test.ts`** — 6 VALOR tests (byte-asserting): populated, empty, idempotent, length-1, length-256 mixed, `allocUnsafeSlow` path.

## Consumers (futuros, en PRs siguientes)

- `cli/infrastructure/prompts/passphrase-prompt.ts` (Q5)
- `cli/infrastructure/prompts/confirm-prompt.ts` (Q5)
- Cualquier callsite que tenga passphrase en Buffer (Q1)

## Validadores pre-merge

- `clean-architecture-validator` → APROBADO
- `solid-validator` → APROBADO

## Spec

- [docs/11 §3](docs/11-seguridad-modos.md) (Formato de la clave de recuperacion)
- [docs/12 §1.5.5 ADR-005 apendice Q1 paso 4 + Q5 paso 5](docs/12-lineamientos-arquitectura.md)

## Test plan

- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` EXIT=0
- [x] `npm run lint:tests` EXIT=0
- [x] 6/6 tests pass
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)