### PR TITLE
feat(encryption): add encryption.audit_log dedicated (ADR-005 Q4)

### DIFF
--- a/code/migrations/009__encryption-audit-log.sql
+++ b/code/migrations/009__encryption-audit-log.sql
@@ -1,0 +1,76 @@
+-- ─────────────────────────────────────────────────────────────────────
+-- 009__encryption-audit-log.sql
+--
+-- ADR-005 Q4 — encryption audit log. Append-only via triggers.
+-- Spec: docs/12 §1.5.5 + HANDOFF §6.27 Phase-22.
+--
+-- Schema CONGELADO (Phase-22, 2026-05-12). DO NOT mutate columns
+-- without a new ADR superseding ADR-005. Field semantics:
+--   - `event_id`         : UUID v7 (16 bytes BLOB).
+--   - `occurred_at_ms`   : epoch ms (matches the codebase convention
+--                          for every `*_at_ms` timestamp,
+--                          docs/03-modelo-datos.md §2).
+--   - `event_type`       : one of the 12 stricto enums documented in
+--                          `EncryptionAuditEventType` (the domain
+--                          discriminated union is the single source
+--                          of truth; the column lacks a CHECK only
+--                          because SQLite cannot keep it in sync with
+--                          the domain type without a manual mirror —
+--                          the application layer guarantees the value
+--                          before INSERT).
+--   - `envelope_id`      : nullable; events like `RekeyStarted` have no
+--                          envelope yet, `UnlockFailed` may have none
+--                          when no envelope matches.
+--   - `master_key_fp`    : SHA-256(master)[:8 bytes] = 16 hex chars
+--                          lowercase. Local-only correlation key
+--                          (NEVER serialise outside this table).
+--   - `actor_hint`       : human-readable origin
+--                          (e.g. "cli:add-key", "mcp:unlock").
+--   - `outcome`          : SUCCESS | FAILURE | TIMEOUT (stricto enum).
+--   - `detail_json`      : metadata WITHOUT secrets
+--                          (kdf_duration_ms, etc.).
+--
+-- Append-only enforcement:
+--   - The two triggers below RAISE(ABORT) on any UPDATE or DELETE
+--     attempt against the table. Persistence-side garbage collection
+--     (rolling retention windows under ADR-005) MUST happen via a
+--     dedicated migration that drops + recreates the table inside a
+--     transaction; in-place mutation of historical rows is a contract
+--     violation.
+--   - There is NO `IF NOT EXISTS` on the triggers because the
+--     migrations runner only applies each migration once and trigger
+--     re-creation conflicts would be a real bug.
+--
+-- Idempotence:
+--   - The runner (`shared/infrastructure/database/migrations-runner.ts`)
+--     skips this migration after the first successful apply via
+--     `schema_migrations`. The CREATE TABLE uses IF NOT EXISTS so
+--     re-running against a database where the table already exists
+--     (e.g. when restoring a partially-migrated workspace) is safe.
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS encryption_audit_log (
+    event_id         BLOB    PRIMARY KEY,   -- UUID v7 16 bytes
+    occurred_at_ms   INTEGER NOT NULL,
+    event_type       TEXT    NOT NULL,      -- stricto enum, see header
+    envelope_id      TEXT,                  -- nullable (e.g. RekeyStarted)
+    master_key_fp    TEXT,                  -- SHA-256(master)[:8 bytes] = 16 hex chars
+    actor_hint       TEXT,                  -- "cli:add-key", "mcp:unlock"
+    outcome          TEXT    NOT NULL,      -- SUCCESS | FAILURE | TIMEOUT
+    detail_json      TEXT                   -- metadata without secrets
+);
+
+CREATE INDEX IF NOT EXISTS idx_eal_ts
+    ON encryption_audit_log (occurred_at_ms DESC);
+
+CREATE TRIGGER eal_no_update
+BEFORE UPDATE ON encryption_audit_log
+BEGIN
+    SELECT RAISE(ABORT, 'audit log is append-only');
+END;
+
+CREATE TRIGGER eal_no_delete
+BEFORE DELETE ON encryption_audit_log
+BEGIN
+    SELECT RAISE(ABORT, 'audit log is append-only');
+END;

--- a/code/src/modules/encryption/domain/repositories/encryption-audit-log-repository.ts
+++ b/code/src/modules/encryption/domain/repositories/encryption-audit-log-repository.ts
@@ -1,0 +1,175 @@
+import type { NonEmptyString } from "../../../../shared/domain/value-objects/non-empty-string.ts";
+import type { Timestamp } from "../../../../shared/domain/value-objects/timestamp.ts";
+import type { EventId } from "../value-objects/event-id.ts";
+import type { KeyId } from "../value-objects/key-id.ts";
+import type { MasterKeyFingerprint } from "../value-objects/master-key-fingerprint.ts";
+
+/**
+ * Stable, exhaustive enumeration of the 12 event types that may be
+ * appended to `encryption_audit_log`.
+ *
+ * **Source-of-truth: ADR-005 Q4 (Phase-22, docs/12 §1.5.5 appendix).**
+ *
+ * Frozen. New event types require a new ADR superseding ADR-005.
+ *
+ * Members:
+ * - `KeyEnvelopeAdded`        : a passphrase envelope was added.
+ * - `KeyEnvelopeRemoved`      : a passphrase envelope was removed.
+ * - `RekeyStarted`            : a rotation of the master key began
+ *                               (no `envelope_id` yet — the new
+ *                               envelope is created during the flow).
+ * - `RekeyCompleted`          : the rotation succeeded.
+ * - `RekeyFailed`             : the rotation failed mid-flow.
+ * - `UnlockSucceeded`         : a passphrase decrypted an envelope.
+ * - `UnlockFailed`            : a passphrase did NOT decrypt any
+ *                               envelope. The row's `envelope_id`
+ *                               is `null` when the failure cannot
+ *                               be attributed to a specific envelope.
+ * - `ExportKeyEmitted`        : an export-key payload was generated.
+ * - `KdfTimeoutExceeded`      : the KDF (argon2id) exceeded its
+ *                               timeout budget.
+ * - `RECOVERY_SKIP_CHECKSUM`  : an admin override skipped the
+ *                               validator-blob check during recovery.
+ * - `KeyValidatorMismatch`    : the validator blob decrypted but the
+ *                               plaintext did NOT match the expected
+ *                               sentinel.
+ * - `LEGACY_KEY_UNLOCK`       : a unlock succeeded using a
+ *                               grandfathered legacy key (pre-ADR-005).
+ */
+export type EncryptionAuditEventType =
+  | "KeyEnvelopeAdded"
+  | "KeyEnvelopeRemoved"
+  | "RekeyStarted"
+  | "RekeyCompleted"
+  | "RekeyFailed"
+  | "UnlockSucceeded"
+  | "UnlockFailed"
+  | "ExportKeyEmitted"
+  | "KdfTimeoutExceeded"
+  | "RECOVERY_SKIP_CHECKSUM"
+  | "KeyValidatorMismatch"
+  | "LEGACY_KEY_UNLOCK";
+
+/**
+ * Stable, exhaustive enumeration of the 3 outcomes that may be
+ * recorded on an `EncryptionAuditEvent`.
+ *
+ * **Source-of-truth: ADR-005 Q4 (Phase-22, docs/12 §1.5.5 appendix).**
+ *
+ * Frozen.
+ *
+ * Members:
+ * - `SUCCESS` : the event completed successfully.
+ * - `FAILURE` : the event failed (any cause other than a timeout).
+ * - `TIMEOUT` : the event failed because a deadline was exceeded.
+ */
+export type EncryptionAuditOutcome = "SUCCESS" | "FAILURE" | "TIMEOUT";
+
+/**
+ * Single immutable record describing one entry of the encryption
+ * audit log.
+ *
+ * **Source-of-truth: ADR-005 Q4 (Phase-22, docs/12 §1.5.5 appendix).**
+ *
+ * Field semantics:
+ * - `eventId`              : UUID v7 identity of this row.
+ * - `occurredAt`           : moment the event happened. Stored as
+ *                            `epoch_ms` in `occurred_at_ms`.
+ * - `eventType`            : one of the 12 frozen strings (see
+ *                            `EncryptionAuditEventType`).
+ * - `envelopeId`           : id of the affected envelope, or `null`
+ *                            when the event has no envelope (e.g.
+ *                            `RekeyStarted`, `UnlockFailed` when no
+ *                            envelope matched).
+ * - `masterKeyFingerprint` : local-only fingerprint of the master
+ *                            key in scope at the time of the event,
+ *                            or `null` when no master key is in
+ *                            scope (e.g. unlock failures, key
+ *                            timeouts).
+ * - `actorHint`            : human-readable origin, e.g.
+ *                            `"cli:add-key"`, `"mcp:unlock"`.
+ * - `outcome`              : `SUCCESS | FAILURE | TIMEOUT`.
+ * - `detailJson`           : free-form metadata associated with the
+ *                            event, e.g. `{ kdf_duration_ms: 245 }`.
+ *                            **MUST NOT** contain secrets, passphrases,
+ *                            derived keys, master keys, envelope
+ *                            ciphertexts, AEAD tags or any other
+ *                            cryptographic material. The application
+ *                            layer enforces this invariant; the
+ *                            persistence adapter trusts the field
+ *                            already obeys the contract.
+ *
+ * Security invariants:
+ * - The whole record is meant to be append-only at the persistence
+ *   boundary; SQLite triggers in migration `009` reject any UPDATE
+ *   or DELETE issued against `encryption_audit_log`.
+ * - `masterKeyFingerprint` is local-only. The audit-log adapter is
+ *   the only site allowed to serialise it. Other consumers MUST
+ *   treat the field as opaque and MUST NOT log, return or transmit
+ *   the value.
+ */
+export interface EncryptionAuditEvent {
+  readonly eventId: EventId;
+  readonly occurredAt: Timestamp;
+  readonly eventType: EncryptionAuditEventType;
+  readonly envelopeId: KeyId | null;
+  readonly masterKeyFingerprint: MasterKeyFingerprint | null;
+  readonly actorHint: NonEmptyString;
+  readonly outcome: EncryptionAuditOutcome;
+  readonly detailJson: Readonly<Record<string, unknown>> | null;
+}
+
+/**
+ * Driven port (output port) for appending entries to the
+ * `encryption_audit_log` table.
+ *
+ * **Source-of-truth: ADR-005 Q4 (Phase-22, docs/12 §1.5.5 appendix).**
+ *
+ * Contract:
+ * - `append` is the **only** operation exposed by this port. The
+ *   audit log is intentionally write-only at the domain boundary —
+ *   nobody calls "read fingerprint" or "list events for envelope X"
+ *   in the running system. Audit consumption happens out-of-band
+ *   (operator running a `recall audit` command, or analysing a
+ *   forensic copy of the database).
+ * - The application layer guarantees `event.detailJson` is free of
+ *   secrets BEFORE calling `append`. The adapter does NOT redact.
+ * - Implementations MUST honour the append-only invariant: any
+ *   future read methods MUST NOT return `masterKeyFingerprint`
+ *   values to callers, only the redacted projection. JSDoc on any
+ *   such method is mandatory and MUST repeat the constraint so the
+ *   reviewer can refuse it during code review.
+ * - Implementations MUST use prepared statements (docs/12 §1 perf).
+ *
+ * Why this port is in `domain/repositories/` and not
+ * `application/ports/out/`:
+ * - The encryption module follows the same convention as every
+ *   other repository in the codebase (`memory/domain/repositories/*`,
+ *   `secrets/domain/repositories/*`, `workspace/domain/repositories/*`,
+ *   etc.): repository contracts live in domain because the
+ *   aggregate's identity is defined there. Renaming them to
+ *   `*.port.ts` and moving them to `application/ports/out/` would
+ *   diverge from the codebase-wide pattern and trigger an architect
+ *   rejection (per `docs/12 §1.5`).
+ */
+export interface EncryptionAuditLogRepository {
+  /**
+   * Appends one event to the `encryption_audit_log` table.
+   *
+   * Implementations MUST:
+   * - Use a prepared statement (cached across calls).
+   * - Persist exactly the fields documented on `EncryptionAuditEvent`.
+   * - Encode `eventId` as a 16-byte UUID v7 BLOB (per the migration
+   *   schema).
+   * - Encode `occurredAt` as `epoch_ms`.
+   * - Encode `detailJson` as a JSON string, or SQL NULL when the
+   *   field is `null`.
+   * - NOT mutate the input.
+   *
+   * @throws Implementation-specific error if the underlying database
+   *         is unreachable or rejects the INSERT (e.g. duplicate
+   *         `event_id` — UUID v7 collisions are practically
+   *         impossible but the adapter still surfaces the SQL error).
+   */
+  append(event: EncryptionAuditEvent): Promise<void>;
+}

--- a/code/src/modules/encryption/domain/value-objects/event-id.ts
+++ b/code/src/modules/encryption/domain/value-objects/event-id.ts
@@ -1,0 +1,46 @@
+import { Id, type IdValue } from "../../../../shared/domain/value-objects/id.ts";
+
+/**
+ * Brand marker for encryption-audit event identifiers. Lives at the
+ * type level only.
+ */
+export type EventIdBrand = "encryption-audit-event";
+
+/**
+ * Identifier of a single `EncryptionAuditEvent` row.
+ *
+ * Mirrors the `event_id` PRIMARY KEY of `encryption_audit_log`
+ * (ADR-005 Q4, docs/12 §1.5.5). The on-disk column is `BLOB` (UUID
+ * v7 16 bytes), but the domain models the identity as the canonical
+ * UUID v7 string — the persistence adapter
+ * (`SqliteEncryptionAuditRepository`) is the single site that
+ * converts between the two representations.
+ *
+ * Why UUID v7 (not autoincrement INTEGER, not random UUID v4):
+ * - Sortable by time, which matches the
+ *   `encryption_audit_log.occurred_at_ms` ordering invariant: rows
+ *   sorted by `event_id` produce the same order as rows sorted by
+ *   `occurred_at_ms` (modulo same-millisecond ties), so an audit
+ *   replay can scan the table in a single forward pass without a
+ *   compound index.
+ * - Consistency with every other aggregate identity in the codebase
+ *   (`WorkspaceId`, `DecisionId`, `LearningId`, `KeyId`, etc.),
+ *   which lets shared infrastructure (logging, tracing) treat all
+ *   ids uniformly.
+ * - Stable across re-imports and migrations (no integer counters
+ *   that would collide when merging two workspaces).
+ *
+ * Inherits the UUID v7 invariants from `Id<EventIdBrand>`; the
+ * brand pins the type so the compiler refuses to mix it with
+ * `WorkspaceId`, `KeyId`, `AuditEventId` (secrets module), etc.
+ */
+export class EventId extends Id<EventIdBrand> {
+  /**
+   * Builds an `EventId` from a raw string. Validates UUID v7 shape
+   * via the inherited `normalize` helper.
+   */
+  public static from(raw: string): EventId {
+    const normalised = Id.normalize(raw, "event_id");
+    return new EventId(normalised as IdValue<EventIdBrand>);
+  }
+}

--- a/code/src/modules/encryption/domain/value-objects/master-key-fingerprint.ts
+++ b/code/src/modules/encryption/domain/value-objects/master-key-fingerprint.ts
@@ -1,0 +1,244 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+
+import { InvalidInputError } from "../../../../shared/domain/errors/invalid-input-error.ts";
+
+/**
+ * Number of bytes of the SHA-256 prefix used as fingerprint.
+ *
+ * Truncating SHA-256 to 8 bytes gives a 64-bit space — more than
+ * enough to correlate audit-log rows for the same master key within a
+ * single workspace (a workspace whose audit log holds 2^32 rows is
+ * already beyond any realistic retention budget; the 64-bit space
+ * absorbs the birthday-paradox margin without bloating the column).
+ */
+const FINGERPRINT_LENGTH_BYTES = 8;
+
+/**
+ * Length, in lowercase hex characters, of the canonical representation.
+ * `FINGERPRINT_LENGTH_BYTES * 2`.
+ */
+const FINGERPRINT_LENGTH_HEX = FINGERPRINT_LENGTH_BYTES * 2;
+
+/**
+ * Length, in bytes, of an AES-256 master key. Mirrors the constant in
+ * `MasterKey`; redeclared here so this VO is self-contained for code
+ * review (the file is the chosen entry point for fingerprint hygiene
+ * audits).
+ */
+const MASTER_KEY_LENGTH_BYTES = 32;
+
+/**
+ * Regex matching the canonical lowercase-hex form. `FINGERPRINT_LENGTH_HEX`
+ * is interpolated at compile time so the literal stays in sync with the
+ * length constants.
+ */
+const FINGERPRINT_HEX_PATTERN = new RegExp(`^[0-9a-f]{${String(FINGERPRINT_LENGTH_HEX)}}$`);
+
+/**
+ * Value object representing a local correlation fingerprint of a
+ * workspace `MasterKey`.
+ *
+ * **Source-of-truth: ADR-005 Q4 (Phase-22, docs/12 §1.5.5 appendix).**
+ *
+ * The fingerprint is `SHA-256(masterKeyBytes)[:8 bytes]`, encoded as
+ * 16 lowercase hex characters. It exists solely to power the
+ * `encryption_audit_log.master_key_fp` column so audit consumers can
+ * answer "which envelopes unlocked the same master key during this
+ * window?" without ever touching the master key itself.
+ *
+ * Security invariants (NON-NEGOTIABLE):
+ * - **Local-only.** Instances MUST NEVER be serialised outside the
+ *   audit-log adapter (`SqliteEncryptionAuditRepository`). The
+ *   adapter writes the hex string into the row; no other adapter is
+ *   allowed to read fingerprints back. No `toJSON`, no logger
+ *   payload, no error message, no wire schema, no CLI output may
+ *   include a fingerprint.
+ * - **Truncated, not derived.** The fingerprint is a *one-way*
+ *   SHA-256 prefix; the master key cannot be reconstructed from it.
+ *   Still, the 64-bit space is small enough that a determined
+ *   attacker with millions of candidate keys could brute-force
+ *   correlations. The mitigation is procedural (the adapter never
+ *   exposes a read API).
+ * - **Constant-time equality.** `equals` iterates the full hex string
+ *   without early return so timing analysis cannot recover the
+ *   fingerprint character by character. The threat model is mild
+ *   (the fingerprint is already truncated) but the cost is zero.
+ * - **Defensive copy at construction.** The factory clones the input
+ *   bytes before hashing so the caller cannot mutate the buffer
+ *   under the VO. JavaScript has no `mlock`-style API; the
+ *   defensive copy keeps the surface for accidental leaks small.
+ *
+ * Why a VO (not a free helper):
+ * - Encodes the invariants of "exactly `FINGERPRINT_LENGTH_HEX`
+ *   lowercase hex characters" once, at construction, so every
+ *   downstream consumer can rely on the shape without revalidating.
+ * - Disables `JSON.stringify` leaks: `toJSON()` returns the redacted
+ *   sentinel so structured loggers (pino, winston) cannot accidentally
+ *   serialise the fingerprint when an `EncryptionAuditEvent` object
+ *   appears inside a log payload.
+ * - Identity by value (`equals`) keeps the audit-log adapter free of
+ *   raw-string comparisons; the type system guarantees nobody mixes
+ *   a fingerprint with a `KeyId` or an `EnvelopeId`.
+ *
+ * Equality:
+ * - Two fingerprints are equal iff their canonical (lowercase hex)
+ *   values match character-for-character.
+ */
+export class MasterKeyFingerprint {
+  /**
+   * Sentinel returned by accessors that could otherwise reveal the
+   * fingerprint in a serialised payload. The bytes are not secret in
+   * the same sense as a master key, but exposing them outside the
+   * audit-log adapter would weaken the procedural barrier described
+   * in the class JSDoc.
+   */
+  private static readonly REDACTED_REPRESENTATION =
+    "<MasterKeyFingerprint:redacted>";
+
+  private constructor(private readonly hex: string) {}
+
+  /**
+   * Computes `SHA-256(masterKeyBytes)[:8 bytes]` and returns it as a
+   * `MasterKeyFingerprint`.
+   *
+   * Validates that the input is a `Uint8Array` of exactly 32 bytes
+   * (an AES-256 master key). Throws `InvalidInputError` for any other
+   * shape; the audit-log adapter relies on the factory to gate
+   * malformed inputs out before they reach SQLite.
+   *
+   * @param masterKeyBytes Raw master-key bytes (e.g. obtained inside a
+   *                       `MasterKey.withBytes(...)` closure).
+   */
+  public static fromMasterKey(masterKeyBytes: Uint8Array): MasterKeyFingerprint {
+    if (!(masterKeyBytes instanceof Uint8Array)) {
+      throw new InvalidInputError(
+        "master key bytes must be a Uint8Array",
+        { field: "master_key_bytes" },
+      );
+    }
+    if (masterKeyBytes.length !== MASTER_KEY_LENGTH_BYTES) {
+      throw new InvalidInputError(
+        `master key bytes must be exactly ${String(MASTER_KEY_LENGTH_BYTES)} bytes (got: ${String(masterKeyBytes.length)})`,
+        { field: "master_key_bytes" },
+      );
+    }
+    // Defensive copy: hashing through `@noble/hashes` does not mutate
+    // the input, but the copy keeps the surface uniform with every
+    // other VO that accepts secret bytes (`MasterKey`, `DerivedKey`).
+    const copy = new Uint8Array(masterKeyBytes);
+    const digest = sha256(copy);
+    const prefix = digest.subarray(0, FINGERPRINT_LENGTH_BYTES);
+    const hex = MasterKeyFingerprint.bytesToHex(prefix);
+    return new MasterKeyFingerprint(hex);
+  }
+
+  /**
+   * Rehydrates a fingerprint from its canonical hex representation.
+   * Used exclusively by the audit-log adapter when reading rows back
+   * for tests; production adapters never expose a read API that
+   * returns fingerprints.
+   *
+   * @param hex Lowercase hex string of length
+   *            `FINGERPRINT_LENGTH_HEX`.
+   */
+  public static fromHex(hex: string): MasterKeyFingerprint {
+    if (typeof hex !== "string") {
+      throw new InvalidInputError(
+        "master key fingerprint hex must be a string",
+        { field: "fingerprint_hex" },
+      );
+    }
+    if (!FINGERPRINT_HEX_PATTERN.test(hex)) {
+      throw new InvalidInputError(
+        `master key fingerprint hex must be ${String(FINGERPRINT_LENGTH_HEX)} lowercase hex characters`,
+        { field: "fingerprint_hex" },
+      );
+    }
+    return new MasterKeyFingerprint(hex);
+  }
+
+  /**
+   * Returns the canonical lowercase-hex form (16 characters). Used by
+   * the audit-log adapter to bind the value to SQLite.
+   *
+   * **Call site discipline:** every caller of `toHex()` MUST be
+   * audited; the method exists only so the persistence adapter can
+   * serialise the value into the `master_key_fp` column.
+   */
+  public toHex(): string {
+    return this.hex;
+  }
+
+  /**
+   * Length, in bytes, of the SHA-256 prefix used as fingerprint.
+   * Exposed for documentation and tests.
+   */
+  public static lengthBytes(): number {
+    return FINGERPRINT_LENGTH_BYTES;
+  }
+
+  /**
+   * Length, in lowercase hex characters, of the canonical
+   * representation. Exposed for documentation and tests.
+   */
+  public static lengthHex(): number {
+    return FINGERPRINT_LENGTH_HEX;
+  }
+
+  /**
+   * Constant-time equality. Iterates the entire string regardless of
+   * the first mismatch so a timing side-channel cannot recover the
+   * fingerprint character by character.
+   */
+  public equals(other: MasterKeyFingerprint): boolean {
+    if (this === other) return true;
+    if (this.hex.length !== other.hex.length) return false;
+    let diff = 0;
+    for (let i = 0; i < this.hex.length; i += 1) {
+      const a = this.hex.charCodeAt(i);
+      const b = other.hex.charCodeAt(i);
+      diff |= a ^ b;
+    }
+    return diff === 0;
+  }
+
+  /**
+   * SAFE BY CONSTRUCTION. Returns the redacted sentinel rather than
+   * the hex string. Template literals, `String(fp)` and many logger
+   * default formatters hit this method.
+   */
+  public toString(): string {
+    return MasterKeyFingerprint.REDACTED_REPRESENTATION;
+  }
+
+  /**
+   * SAFE BY CONSTRUCTION. `JSON.stringify` calls `toJSON` when
+   * present, so structured logging frameworks (pino, winston) emit
+   * the redacted sentinel — never the actual fingerprint — when an
+   * audit-event object is logged. The audit-log adapter intentionally
+   * bypasses this method by calling `toHex()` explicitly at the
+   * persistence boundary.
+   */
+  public toJSON(): string {
+    return MasterKeyFingerprint.REDACTED_REPRESENTATION;
+  }
+
+  /**
+   * Hex encoder. Implemented in-line so the VO is self-contained and
+   * the hot path stays a tight loop over a typed array.
+   *
+   * Uses `String.prototype.padStart` over each byte's `toString(16)`
+   * representation: simple, branch-free (modulo the padStart fast
+   * path inside V8) and `noUncheckedIndexedAccess`-friendly (no
+   * indexed lookups into a digit-table string, which would surface
+   * `string | undefined` and force a non-null assertion banned by
+   * `@typescript-eslint/no-non-null-assertion`).
+   */
+  private static bytesToHex(bytes: Uint8Array): string {
+    let out = "";
+    for (const byte of bytes) {
+      out += byte.toString(16).padStart(2, "0");
+    }
+    return out;
+  }
+}

--- a/code/src/modules/encryption/domain/value-objects/master-key-fingerprint.ts
+++ b/code/src/modules/encryption/domain/value-objects/master-key-fingerprint.ts
@@ -195,8 +195,8 @@ export class MasterKeyFingerprint {
     if (this.hex.length !== other.hex.length) return false;
     let diff = 0;
     for (let i = 0; i < this.hex.length; i += 1) {
-      const a = this.hex.charCodeAt(i);
-      const b = other.hex.charCodeAt(i);
+      const a = this.hex.codePointAt(i) ?? 0;
+      const b = other.hex.codePointAt(i) ?? 0;
       diff |= a ^ b;
     }
     return diff === 0;

--- a/code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts
+++ b/code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts
@@ -127,7 +127,12 @@ export class SqliteEncryptionAuditRepository
    * the contents into the SQLCipher BLOB slot during `run`, so the
    * adapter does not retain a reference past the call.
    */
-  public append(event: EncryptionAuditEvent): Promise<void> {
+  // Async signature mantiene compatibilidad con el puerto (Promise<void>)
+  // y preserva la semantica de rejection cuando uuidStringToBytes lanza.
+  // require-await se desactiva localmente: better-sqlite3 es sync; no hay
+  // await real pero la firma debe ser Promise<void> por contrato.
+  // eslint-disable-next-line @typescript-eslint/require-await
+  public async append(event: EncryptionAuditEvent): Promise<void> {
     const eventIdBytes = SqliteEncryptionAuditRepository.uuidStringToBytes(
       event.eventId.toString(),
     );
@@ -157,8 +162,6 @@ export class SqliteEncryptionAuditRepository
       event.outcome,
       detailJsonSql,
     );
-
-    return Promise.resolve();
   }
 
   // -- internals --------------------------------------------------------

--- a/code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts
+++ b/code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts
@@ -127,7 +127,7 @@ export class SqliteEncryptionAuditRepository
    * the contents into the SQLCipher BLOB slot during `run`, so the
    * adapter does not retain a reference past the call.
    */
-  public async append(event: EncryptionAuditEvent): Promise<void> {
+  public append(event: EncryptionAuditEvent): Promise<void> {
     const eventIdBytes = SqliteEncryptionAuditRepository.uuidStringToBytes(
       event.eventId.toString(),
     );
@@ -177,7 +177,7 @@ export class SqliteEncryptionAuditRepository
    * raw string to the repository.
    */
   private static uuidStringToBytes(uuid: string): Uint8Array {
-    const hex = uuid.replace(/-/g, "");
+    const hex = uuid.replaceAll("-", "");
     if (hex.length !== UUID_HEX_LENGTH) {
       throw new Error(
         `event_id must canonically be a UUID v7 (32 hex digits after stripping dashes; got: ${String(hex.length)})`,

--- a/code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts
+++ b/code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts
@@ -1,0 +1,200 @@
+import type {
+  DatabaseConnection,
+  PreparedStatement,
+} from "../../../../shared/application/ports/database-connection.port.ts";
+import type {
+  EncryptionAuditEvent,
+  EncryptionAuditLogRepository,
+} from "../../domain/repositories/encryption-audit-log-repository.ts";
+
+/**
+ * Length, in bytes, of an `event_id` BLOB. UUID v7 is a 128-bit
+ * identifier, hence exactly 16 bytes.
+ */
+const EVENT_ID_LENGTH_BYTES = 16;
+
+/**
+ * Number of canonical UUID hex digits (excludes the four dashes).
+ * Used by the encoder to sanity-check the input string before
+ * decoding.
+ */
+const UUID_HEX_LENGTH = EVENT_ID_LENGTH_BYTES * 2;
+
+/**
+ * SQL DDL for the audit-log table.
+ *
+ * The migration that ships this schema is
+ * `code/migrations/009__encryption-audit-log.sql`. The DDL constant
+ * lives below in JSDoc form for code review:
+ *
+ * ```sql
+ * CREATE TABLE encryption_audit_log (
+ *     event_id         BLOB    PRIMARY KEY,
+ *     occurred_at_ms   INTEGER NOT NULL,
+ *     event_type       TEXT    NOT NULL,
+ *     envelope_id      TEXT,
+ *     master_key_fp    TEXT,
+ *     actor_hint       TEXT,
+ *     outcome          TEXT    NOT NULL,
+ *     detail_json      TEXT
+ * );
+ * CREATE INDEX idx_eal_ts ON encryption_audit_log (occurred_at_ms DESC);
+ * CREATE TRIGGER eal_no_update BEFORE UPDATE ON encryption_audit_log
+ *   BEGIN SELECT RAISE(ABORT, 'audit log is append-only'); END;
+ * CREATE TRIGGER eal_no_delete BEFORE DELETE ON encryption_audit_log
+ *   BEGIN SELECT RAISE(ABORT, 'audit log is append-only'); END;
+ * ```
+ */
+
+const SQL_INSERT = `
+INSERT INTO encryption_audit_log (
+    event_id,
+    occurred_at_ms,
+    event_type,
+    envelope_id,
+    master_key_fp,
+    actor_hint,
+    outcome,
+    detail_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`.trim();
+
+/**
+ * Adapter that fulfils the `EncryptionAuditLogRepository` domain port
+ * using the SQLite `encryption_audit_log` table (migration 009).
+ *
+ * **Source-of-truth: ADR-005 Q4 (Phase-22, docs/12 §1.5.5 appendix).**
+ *
+ * Persistence shape:
+ * - One row per `EncryptionAuditEvent`. The `event_id` is encoded as
+ *   a 16-byte BLOB (the canonical UUID v7 string is parsed into raw
+ *   bytes by `SqliteEncryptionAuditRepository.uuidStringToBytes`).
+ * - `occurred_at_ms` is the millisecond epoch integer.
+ * - `event_type` is one of the 12 frozen `EncryptionAuditEventType`
+ *   strings — persisted verbatim.
+ * - `envelope_id` is the canonical UUID v7 string of the affected
+ *   envelope, or SQL NULL.
+ * - `master_key_fp` is the 16-character lowercase hex fingerprint
+ *   (see `MasterKeyFingerprint`), or SQL NULL.
+ * - `actor_hint` is the canonical trimmed `NonEmptyString` value.
+ * - `outcome` is `SUCCESS | FAILURE | TIMEOUT` verbatim.
+ * - `detail_json` is `JSON.stringify(event.detailJson)` or SQL NULL
+ *   when the input field is null.
+ *
+ * Invariants:
+ * - **Append-only enforcement happens at the SQLite layer**. The
+ *   migration installs `eal_no_update` and `eal_no_delete` triggers
+ *   that RAISE(ABORT) with the canonical error message
+ *   `"audit log is append-only"`. The adapter therefore does NOT
+ *   expose `delete` or `update` methods (and never will).
+ * - The `master_key_fingerprint` field is local-only. Callers MUST
+ *   NOT be given a public read API that returns the fingerprint
+ *   back. Any future method intended to read audit rows (for an
+ *   `mem.audit` flow, a forensic export, etc.) MUST redact the
+ *   fingerprint or document a JSDoc constraint that callers cannot
+ *   use the returned value outside the audit subsystem. Code review
+ *   enforces this rule.
+ *
+ * Why no `findBy*`, no `count`, no `iterate`:
+ * - This adapter is **strictly write-only by design**. ADR-005 Q4
+ *   ships the read path to a dedicated `recall audit` CLI command
+ *   that opens its own forensic SQLite handle; the running server
+ *   never reads the audit log back, so the port stays minimal.
+ *   Removing the temptation of an in-process read API also keeps
+ *   the master-key-fingerprint procedural barrier intact.
+ *
+ * Prepared statement caching:
+ * - The adapter caches the `INSERT` statement on construction. The
+ *   `DatabaseConnection` port allows implementations to cache, but
+ *   the cache is per-statement-string; pinning the prepared object
+ *   on `this` removes the lookup cost from the hot path
+ *   (docs/12 §1 perf).
+ */
+export class SqliteEncryptionAuditRepository
+  implements EncryptionAuditLogRepository
+{
+  private readonly insertStmt: PreparedStatement;
+
+  public constructor(db: DatabaseConnection) {
+    this.insertStmt = db.prepare(SQL_INSERT);
+  }
+
+  /**
+   * Appends one event to `encryption_audit_log`.
+   *
+   * Buffer ownership: `event_id` is parsed into a fresh
+   * `Uint8Array` of length 16; the better-sqlite3 driver copies
+   * the contents into the SQLCipher BLOB slot during `run`, so the
+   * adapter does not retain a reference past the call.
+   */
+  public async append(event: EncryptionAuditEvent): Promise<void> {
+    const eventIdBytes = SqliteEncryptionAuditRepository.uuidStringToBytes(
+      event.eventId.toString(),
+    );
+    const eventIdBuffer = Buffer.from(
+      eventIdBytes.buffer,
+      eventIdBytes.byteOffset,
+      eventIdBytes.byteLength,
+    );
+
+    const envelopeIdSql: string | null =
+      event.envelopeId === null ? null : event.envelopeId.toString();
+    const masterKeyFpSql: string | null =
+      event.masterKeyFingerprint === null
+        ? null
+        : event.masterKeyFingerprint.toHex();
+    const actorHintSql: string = event.actorHint.toString();
+    const detailJsonSql: string | null =
+      event.detailJson === null ? null : JSON.stringify(event.detailJson);
+
+    this.insertStmt.run(
+      eventIdBuffer,
+      event.occurredAt.epochMs,
+      event.eventType,
+      envelopeIdSql,
+      masterKeyFpSql,
+      actorHintSql,
+      event.outcome,
+      detailJsonSql,
+    );
+
+    return Promise.resolve();
+  }
+
+  // -- internals --------------------------------------------------------
+
+  /**
+   * Parses a canonical UUID v7 string
+   * (`xxxxxxxx-xxxx-7xxx-[8|9|a|b]xxx-xxxxxxxxxxxx`) into the
+   * underlying 16-byte representation expected by the `event_id`
+   * BLOB column.
+   *
+   * The `EventId` value object has already validated the shape at
+   * the domain boundary, so this helper trusts the input is canonical
+   * (lowercase hex with dashes in the right positions). It still
+   * defends against malformed input — a defence-in-depth check that
+   * pays for itself if a future caller bypasses the VO and binds a
+   * raw string to the repository.
+   */
+  private static uuidStringToBytes(uuid: string): Uint8Array {
+    const hex = uuid.replace(/-/g, "");
+    if (hex.length !== UUID_HEX_LENGTH) {
+      throw new Error(
+        `event_id must canonically be a UUID v7 (32 hex digits after stripping dashes; got: ${String(hex.length)})`,
+      );
+    }
+    const bytes = new Uint8Array(EVENT_ID_LENGTH_BYTES);
+    for (let i = 0; i < EVENT_ID_LENGTH_BYTES; i += 1) {
+      const start = i * 2;
+      const slice = hex.slice(start, start + 2);
+      const value = Number.parseInt(slice, 16);
+      if (!Number.isFinite(value) || value < 0 || value > 0xff) {
+        throw new Error(
+          `event_id contains a non-hex byte at offset ${String(start)} ("${slice}")`,
+        );
+      }
+      bytes[i] = value;
+    }
+    return bytes;
+  }
+}

--- a/code/tests/integration/encryption/sqlite-encryption-audit-repository.integration.test.ts
+++ b/code/tests/integration/encryption/sqlite-encryption-audit-repository.integration.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Integration test — `SqliteEncryptionAuditRepository`.
+ *
+ * **Source-of-truth: ADR-005 Q4 (Phase-22, docs/12 §1.5.5 appendix).**
+ *
+ * Drives the adapter against a real on-disk SQLite database after
+ * running every migration (so `encryption_audit_log` is present with
+ * its append-only triggers). Tests verify:
+ *
+ *   - Happy-path INSERT covers every field (event_id BLOB, null
+ *     envelope, null fingerprint, JSON detail).
+ *   - The two triggers `eal_no_update` / `eal_no_delete` actually
+ *     reject mutations with the canonical error message.
+ *   - All 12 `EncryptionAuditEventType` strings round-trip verbatim.
+ *   - All 3 `EncryptionAuditOutcome` strings round-trip verbatim.
+ *   - The `idx_eal_ts` index enables ORDER BY occurred_at_ms DESC.
+ *
+ * The tests reach into the SQLite table directly via the
+ * `DatabaseConnection` port (rather than going through the
+ * write-only repository's public surface) because the audit-log
+ * adapter is intentionally strict on its read side — see
+ * `SqliteEncryptionAuditRepository` JSDoc on why there is no
+ * `find*` API.
+ */
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { EventId } from "../../../src/modules/encryption/domain/value-objects/event-id.ts";
+import { KeyId } from "../../../src/modules/encryption/domain/value-objects/key-id.ts";
+import { MasterKeyFingerprint } from "../../../src/modules/encryption/domain/value-objects/master-key-fingerprint.ts";
+import { SqliteEncryptionAuditRepository } from "../../../src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts";
+import type {
+  EncryptionAuditEvent,
+  EncryptionAuditEventType,
+  EncryptionAuditOutcome,
+} from "../../../src/modules/encryption/domain/repositories/encryption-audit-log-repository.ts";
+import { NonEmptyString } from "../../../src/shared/domain/value-objects/non-empty-string.ts";
+import { Timestamp } from "../../../src/shared/domain/value-objects/timestamp.ts";
+import {
+  SqliteDatabase,
+  type SqliteDatabaseOpenOptions,
+} from "../../../src/shared/infrastructure/database/sqlite-database.ts";
+import { MigrationsRunner } from "../../../src/shared/infrastructure/database/migrations-runner.ts";
+import { RecordingLogger } from "../../_fixtures/silent-logger.ts";
+
+/**
+ * Pre-generated UUID v7 fixtures used across the suite. Hand-picked
+ * so the suite is reproducible (no `uuid.v7()` calls at runtime, no
+ * non-determinism).
+ *
+ * Each id is a valid canonical UUID v7 (version nibble `7`, variant
+ * nibble in `{8,9,a,b}`). The trailing octets are distinct so tests
+ * that need multiple ids can pick them without collisions.
+ */
+const EVENT_ID_1 = "019e1de3-6015-76e1-a3aa-e882b6a6809f";
+const EVENT_ID_2 = "019e1de3-6017-71b6-919d-321d064575da";
+const EVENT_ID_3 = "019e1de3-6017-71b6-919d-35204ca8768e";
+
+const ENVELOPE_ID_1 = "019e1de3-6017-71b6-919d-3a3c178f1a0f";
+const ENVELOPE_ID_2 = "019e1de3-6017-71b6-919d-3f50748a1ed9";
+
+const ANCHOR_MS = 1_745_000_000_000;
+
+/**
+ * The 12 frozen `EncryptionAuditEventType` strings. Declared as a
+ * `const` array so the loop in the round-trip test can iterate them
+ * exhaustively. A type-level cross-check below asserts the array
+ * matches the union.
+ */
+const ALL_EVENT_TYPES = [
+  "KeyEnvelopeAdded",
+  "KeyEnvelopeRemoved",
+  "RekeyStarted",
+  "RekeyCompleted",
+  "RekeyFailed",
+  "UnlockSucceeded",
+  "UnlockFailed",
+  "ExportKeyEmitted",
+  "KdfTimeoutExceeded",
+  "RECOVERY_SKIP_CHECKSUM",
+  "KeyValidatorMismatch",
+  "LEGACY_KEY_UNLOCK",
+] as const satisfies readonly EncryptionAuditEventType[];
+
+const ALL_OUTCOMES = [
+  "SUCCESS",
+  "FAILURE",
+  "TIMEOUT",
+] as const satisfies readonly EncryptionAuditOutcome[];
+
+const MIGRATIONS_DIR = path.resolve(
+  // tests/integration/encryption/ → code/, then migrations
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "migrations",
+);
+
+let tmpDir: string;
+let dbPath: string;
+let database: SqliteDatabase;
+let repo: SqliteEncryptionAuditRepository;
+let logger: RecordingLogger;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "recall-eal-"));
+  dbPath = path.join(tmpDir, "audit.db");
+  logger = new RecordingLogger();
+  const openOptions: SqliteDatabaseOpenOptions = {
+    path: dbPath,
+    loadVectorExtension: true,
+    logger,
+  };
+  database = await SqliteDatabase.open(openOptions);
+  const runner = new MigrationsRunner(logger);
+  await runner.run(database, MIGRATIONS_DIR);
+  repo = new SqliteEncryptionAuditRepository(database);
+});
+
+afterEach(async () => {
+  try {
+    database.close();
+  } catch {
+    // already closed
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+});
+
+/**
+ * Builds a fully-populated event with sane defaults. Tests override
+ * the fields they exercise.
+ */
+function buildEvent(
+  overrides: Partial<EncryptionAuditEvent> = {},
+): EncryptionAuditEvent {
+  const masterKeyBytes = new Uint8Array(32);
+  masterKeyBytes.fill(0x42);
+
+  const base: EncryptionAuditEvent = {
+    eventId: EventId.from(EVENT_ID_1),
+    occurredAt: Timestamp.fromEpochMs(ANCHOR_MS),
+    eventType: "KeyEnvelopeAdded",
+    envelopeId: KeyId.from(ENVELOPE_ID_1),
+    masterKeyFingerprint: MasterKeyFingerprint.fromMasterKey(masterKeyBytes),
+    actorHint: NonEmptyString.create("cli:add-key", "actor_hint"),
+    outcome: "SUCCESS",
+    detailJson: { kdf_duration_ms: 245, source: "test" },
+  };
+  return { ...base, ...overrides };
+}
+
+interface AuditRow {
+  readonly event_id: Buffer;
+  readonly occurred_at_ms: number;
+  readonly event_type: string;
+  readonly envelope_id: string | null;
+  readonly master_key_fp: string | null;
+  readonly actor_hint: string | null;
+  readonly outcome: string;
+  readonly detail_json: string | null;
+}
+
+function selectAll(): readonly AuditRow[] {
+  const stmt = database.prepare(
+    `SELECT event_id, occurred_at_ms, event_type, envelope_id,
+            master_key_fp, actor_hint, outcome, detail_json
+       FROM encryption_audit_log
+       ORDER BY occurred_at_ms ASC`,
+  );
+  return stmt.all() as readonly AuditRow[];
+}
+
+describe("SqliteEncryptionAuditRepository.append — persistence shape", () => {
+  it("persists every field of a fully-populated event", async () => {
+    const event = buildEvent();
+    await repo.append(event);
+
+    const rows = selectAll();
+    expect(rows.length).toBe(1);
+    const row = rows[0];
+    expect(row).toBeDefined();
+    if (row === undefined) return;
+
+    // event_id is a 16-byte BLOB.
+    expect(Buffer.isBuffer(row.event_id) || row.event_id instanceof Uint8Array).toBe(true);
+    expect(row.event_id.length).toBe(16);
+    expect(row.occurred_at_ms).toBe(ANCHOR_MS);
+    expect(row.event_type).toBe("KeyEnvelopeAdded");
+    expect(row.envelope_id).toBe(ENVELOPE_ID_1);
+    // 16 hex chars (8 bytes × 2).
+    expect(row.master_key_fp).not.toBeNull();
+    expect((row.master_key_fp ?? "").length).toBe(16);
+    expect(/^[0-9a-f]{16}$/.test(row.master_key_fp ?? "")).toBe(true);
+    expect(row.actor_hint).toBe("cli:add-key");
+    expect(row.outcome).toBe("SUCCESS");
+    expect(row.detail_json).not.toBeNull();
+    const detail = JSON.parse(row.detail_json ?? "{}") as Record<string, unknown>;
+    expect(detail["kdf_duration_ms"]).toBe(245);
+    expect(detail["source"]).toBe("test");
+  });
+
+  it("persists null envelope_id (e.g. RekeyStarted)", async () => {
+    const event = buildEvent({
+      eventType: "RekeyStarted",
+      envelopeId: null,
+    });
+    await repo.append(event);
+
+    const rows = selectAll();
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.event_type).toBe("RekeyStarted");
+    expect(rows[0]?.envelope_id).toBeNull();
+  });
+
+  it("persists null master_key_fingerprint (e.g. UnlockFailed with no envelope match)", async () => {
+    const event = buildEvent({
+      eventId: EventId.from(EVENT_ID_2),
+      eventType: "UnlockFailed",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      outcome: "FAILURE",
+      detailJson: null,
+    });
+    await repo.append(event);
+
+    const rows = selectAll();
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.event_type).toBe("UnlockFailed");
+    expect(rows[0]?.envelope_id).toBeNull();
+    expect(rows[0]?.master_key_fp).toBeNull();
+    expect(rows[0]?.outcome).toBe("FAILURE");
+    expect(rows[0]?.detail_json).toBeNull();
+  });
+});
+
+/**
+ * Helper: captures the error thrown by `run()` and walks the `cause`
+ * chain so we can assert on the original SQLite message even though
+ * the adapter wraps every driver error in `DatabaseError.execFailed`.
+ *
+ * The pattern is: `DatabaseError("failed to execute SQL batch")` with
+ * `cause = SqliteError("audit log is append-only", ...)`.
+ */
+function captureRunError(fn: () => void): Error | null {
+  try {
+    fn();
+    return null;
+  } catch (e: unknown) {
+    return e instanceof Error ? e : new Error(String(e));
+  }
+}
+
+function messageChain(err: Error): string {
+  const messages: string[] = [err.message];
+  let current: unknown = (err as { cause?: unknown }).cause;
+  while (current !== undefined && current !== null) {
+    if (current instanceof Error) {
+      messages.push(current.message);
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      messages.push(String(current));
+      break;
+    }
+  }
+  return messages.join(" | ");
+}
+
+describe("SqliteEncryptionAuditRepository.append — append-only enforcement", () => {
+  it("rejects UPDATE via the eal_no_update trigger", async () => {
+    await repo.append(buildEvent());
+
+    const update = database.prepare(
+      "UPDATE encryption_audit_log SET outcome = ? WHERE outcome = ?",
+    );
+    const err = captureRunError(() => {
+      update.run("FAILURE", "SUCCESS");
+    });
+    expect(err).not.toBeNull();
+    if (err !== null) {
+      // The adapter wraps the driver error in DatabaseError.execFailed,
+      // but the original SQLite RAISE(ABORT) message is preserved on
+      // the cause chain. Verifying via the chain is the contractually
+      // correct read because it documents both layers (the port-level
+      // wrapper AND the migration-defined trigger message).
+      expect(messageChain(err)).toMatch(/audit log is append-only/);
+    }
+
+    // Original row is intact.
+    const rows = selectAll();
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.outcome).toBe("SUCCESS");
+  });
+
+  it("rejects DELETE via the eal_no_delete trigger", async () => {
+    await repo.append(buildEvent());
+
+    const del = database.prepare(
+      "DELETE FROM encryption_audit_log WHERE event_type = ?",
+    );
+    const err = captureRunError(() => {
+      del.run("KeyEnvelopeAdded");
+    });
+    expect(err).not.toBeNull();
+    if (err !== null) {
+      expect(messageChain(err)).toMatch(/audit log is append-only/);
+    }
+
+    // Row survives the failed DELETE.
+    const rows = selectAll();
+    expect(rows.length).toBe(1);
+  });
+});
+
+describe("SqliteEncryptionAuditRepository.append — enum coverage", () => {
+  it("round-trips all 12 EncryptionAuditEventType values", async () => {
+    // Use distinct event_ids so the PRIMARY KEY does not collide.
+    // We synthesise them by varying the last digit of EVENT_ID_2.
+    // The last hex octet has to keep the lowercase-hex shape; we
+    // walk 0..b to stay valid.
+    const HEX = "0123456789ab";
+    for (let i = 0; i < ALL_EVENT_TYPES.length; i += 1) {
+      const digit = HEX[i] ?? "0";
+      const id = `019e1de3-6017-71b6-919d-35204ca876${digit}e`;
+      await repo.append(
+        buildEvent({
+          eventId: EventId.from(id),
+          eventType: ALL_EVENT_TYPES[i] ?? "KeyEnvelopeAdded",
+          occurredAt: Timestamp.fromEpochMs(ANCHOR_MS + i),
+        }),
+      );
+    }
+
+    const rows = selectAll();
+    expect(rows.length).toBe(ALL_EVENT_TYPES.length);
+    for (let i = 0; i < ALL_EVENT_TYPES.length; i += 1) {
+      expect(rows[i]?.event_type).toBe(ALL_EVENT_TYPES[i]);
+    }
+  });
+
+  it("round-trips all 3 EncryptionAuditOutcome values", async () => {
+    const ids = [EVENT_ID_1, EVENT_ID_2, EVENT_ID_3];
+    for (let i = 0; i < ALL_OUTCOMES.length; i += 1) {
+      await repo.append(
+        buildEvent({
+          eventId: EventId.from(ids[i] ?? EVENT_ID_1),
+          outcome: ALL_OUTCOMES[i] ?? "SUCCESS",
+          occurredAt: Timestamp.fromEpochMs(ANCHOR_MS + i),
+        }),
+      );
+    }
+    const rows = selectAll();
+    expect(rows.length).toBe(ALL_OUTCOMES.length);
+    expect(rows.map((r) => r.outcome)).toEqual([
+      "SUCCESS",
+      "FAILURE",
+      "TIMEOUT",
+    ]);
+  });
+});
+
+describe("SqliteEncryptionAuditRepository.append — defence-in-depth on event_id parsing", () => {
+  /**
+   * The adapter's private `uuidStringToBytes` validates the hex shape
+   * even though `EventId` already does. The two guards below are
+   * normally unreachable in production (the VO would reject the
+   * input first), but a future caller might bypass the VO; the
+   * defence-in-depth tests below prove the guard fires.
+   *
+   * We reach the private code path by constructing an event that
+   * looks well-formed to TypeScript (the VO factory accepts the
+   * canonical input) and then mutating the underlying value via
+   * `Object.defineProperty` to inject the bad shape after
+   * construction — exclusively for the guard test.
+   */
+  it("rejects an event_id whose dash-stripped length is not 32 hex digits", async () => {
+    const event = buildEvent();
+    const fakeEventId = {
+      toString: (): string => "deadbeef", // 8 chars, far from 32
+    };
+    Object.defineProperty(event, "eventId", {
+      value: fakeEventId,
+      writable: false,
+      configurable: false,
+    });
+    await expect(repo.append(event)).rejects.toThrow(
+      /event_id must canonically be a UUID v7/,
+    );
+  });
+
+  it("rejects an event_id with non-hex characters after dash-stripping", async () => {
+    const event = buildEvent();
+    // 32 chars, but containing non-hex "zz".
+    const fakeEventId = {
+      toString: (): string => "zzdeadbeefdeadbeefdeadbeefdeadbe",
+    };
+    Object.defineProperty(event, "eventId", {
+      value: fakeEventId,
+      writable: false,
+      configurable: false,
+    });
+    await expect(repo.append(event)).rejects.toThrow(
+      /event_id contains a non-hex byte/,
+    );
+  });
+});
+
+describe("SqliteEncryptionAuditRepository.append — ordering / index", () => {
+  it("supports ORDER BY occurred_at_ms DESC via idx_eal_ts", async () => {
+    await repo.append(
+      buildEvent({
+        eventId: EventId.from(EVENT_ID_1),
+        occurredAt: Timestamp.fromEpochMs(ANCHOR_MS + 1),
+        envelopeId: KeyId.from(ENVELOPE_ID_1),
+      }),
+    );
+    await repo.append(
+      buildEvent({
+        eventId: EventId.from(EVENT_ID_2),
+        occurredAt: Timestamp.fromEpochMs(ANCHOR_MS + 2),
+        envelopeId: KeyId.from(ENVELOPE_ID_2),
+      }),
+    );
+    await repo.append(
+      buildEvent({
+        eventId: EventId.from(EVENT_ID_3),
+        occurredAt: Timestamp.fromEpochMs(ANCHOR_MS + 3),
+        envelopeId: KeyId.from(ENVELOPE_ID_1),
+      }),
+    );
+
+    const stmt = database.prepare(
+      `SELECT occurred_at_ms
+         FROM encryption_audit_log
+         ORDER BY occurred_at_ms DESC`,
+    );
+    const rows = stmt.all() as readonly { occurred_at_ms: number }[];
+    expect(rows.length).toBe(3);
+    expect(rows.map((r) => r.occurred_at_ms)).toEqual([
+      ANCHOR_MS + 3,
+      ANCHOR_MS + 2,
+      ANCHOR_MS + 1,
+    ]);
+
+    // Verify the planner actually uses the index. EXPLAIN QUERY PLAN
+    // returns rows with a `detail` column whose text mentions
+    // "USING INDEX idx_eal_ts" when the index is exercised.
+    const planStmt = database.prepare(
+      `EXPLAIN QUERY PLAN
+         SELECT occurred_at_ms
+           FROM encryption_audit_log
+           ORDER BY occurred_at_ms DESC`,
+    );
+    const planRows = planStmt.all() as readonly { detail: string }[];
+    const planText = planRows.map((r) => r.detail).join("\n");
+    // Either the index is used directly, or SQLite reports it
+    // explicitly. The exact wording varies across SQLite versions;
+    // we accept either canonical phrasing.
+    expect(/idx_eal_ts/.test(planText)).toBe(true);
+  });
+});

--- a/code/tests/integration/smoke.test.ts
+++ b/code/tests/integration/smoke.test.ts
@@ -47,7 +47,10 @@ describe("integration / smoke / container wiring", () => {
     // Migration 008 (B-MCP-4 / issue #3) adds the `decisions.content`
     // column and rebuilds the FTS5 index over it so the wire `content`
     // field stops being silently dropped on `mem.remember`.
-    expect(versions).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    // Migration 009 (ADR-005 Q4 — Phase-22) creates the
+    // `encryption_audit_log` table with append-only triggers for the
+    // multi-key envelope flow audit trail.
+    expect(versions).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 
   it("registered the six MVP tools on the registry", () => {

--- a/code/tests/unit/encryption/domain/value-objects/master-key-fingerprint.test.ts
+++ b/code/tests/unit/encryption/domain/value-objects/master-key-fingerprint.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for `MasterKeyFingerprint`.
+ *
+ * **Source-of-truth: ADR-005 Q4 (Phase-22, docs/12 §1.5.5 appendix).**
+ *
+ * Coverage:
+ *   - Vector tests with known SHA-256 prefixes (32 bytes of `0x00`
+ *     and 32 bytes of `0xff`) to nail down the algorithm.
+ *   - Shape invariants (16 lowercase hex chars).
+ *   - Defensive copy at construction (caller can mutate input
+ *     without affecting the VO).
+ *   - `equals` symmetry / reflexivity / inequality.
+ *   - `toString` / `toJSON` redaction sentinels (the fingerprint is
+ *     local-only and MUST NOT leak via template literals or
+ *     `JSON.stringify`).
+ *   - Rejected inputs (wrong type, wrong length, wrong hex shape).
+ */
+import { describe, it, expect } from "vitest";
+
+import { MasterKeyFingerprint } from "../../../../../src/modules/encryption/domain/value-objects/master-key-fingerprint.ts";
+import { InvalidInputError } from "../../../../../src/shared/domain/errors/invalid-input-error.ts";
+
+// Pre-computed SHA-256 prefixes for canonical inputs.
+//   echo -n "<32 bytes of 0x00>" | sha256sum → 66687aad... (full hash)
+//   first 8 bytes → 66687aadf862bd77
+const ZERO_KEY_PREFIX = "66687aadf862bd77";
+const FF_KEY_PREFIX = "af9613760f72635f";
+
+describe("MasterKeyFingerprint.fromMasterKey — known vectors", () => {
+  it("produces the expected prefix for 32 bytes of 0x00", () => {
+    const key = new Uint8Array(32); // initialised to 0x00 by spec
+    const fp = MasterKeyFingerprint.fromMasterKey(key);
+    expect(fp.toHex()).toBe(ZERO_KEY_PREFIX);
+  });
+
+  it("produces the expected prefix for 32 bytes of 0xff", () => {
+    const key = new Uint8Array(32);
+    key.fill(0xff);
+    const fp = MasterKeyFingerprint.fromMasterKey(key);
+    expect(fp.toHex()).toBe(FF_KEY_PREFIX);
+  });
+
+  it("returns exactly 16 lowercase hex characters", () => {
+    const key = new Uint8Array(32);
+    key.fill(0x42);
+    const fp = MasterKeyFingerprint.fromMasterKey(key);
+    const hex = fp.toHex();
+    expect(hex.length).toBe(16);
+    expect(/^[0-9a-f]{16}$/.test(hex)).toBe(true);
+  });
+
+  it("produces different hex strings for unrelated random keys", () => {
+    const keys: MasterKeyFingerprint[] = [];
+    for (let i = 0; i < 8; i += 1) {
+      const k = new Uint8Array(32);
+      // Each byte = i + position so each key is distinct and not
+      // structurally similar to the others.
+      for (let j = 0; j < 32; j += 1) k[j] = (i * 31 + j) & 0xff;
+      keys.push(MasterKeyFingerprint.fromMasterKey(k));
+    }
+    const hexes = keys.map((fp) => fp.toHex());
+    const unique = new Set(hexes);
+    // Eight distinct inputs → eight distinct 64-bit fingerprints
+    // (collision probability is ~zero at this scale).
+    expect(unique.size).toBe(8);
+  });
+
+  it("is stable: same input → same fingerprint", () => {
+    const key = new Uint8Array(32);
+    for (let i = 0; i < 32; i += 1) key[i] = i;
+    const a = MasterKeyFingerprint.fromMasterKey(key);
+    const b = MasterKeyFingerprint.fromMasterKey(key);
+    expect(a.toHex()).toBe(b.toHex());
+  });
+
+  it("defensive copy: mutating the caller's buffer after construction does not change the fingerprint", () => {
+    const key = new Uint8Array(32);
+    key.fill(0x00);
+    const fp = MasterKeyFingerprint.fromMasterKey(key);
+    const before = fp.toHex();
+    // Mutate AFTER construction.
+    key.fill(0xff);
+    expect(fp.toHex()).toBe(before);
+    // And the post-mutation result for a fresh call differs.
+    const fpAfter = MasterKeyFingerprint.fromMasterKey(key);
+    expect(fpAfter.toHex()).not.toBe(before);
+  });
+});
+
+describe("MasterKeyFingerprint.fromMasterKey — input validation", () => {
+  it("rejects a non-Uint8Array input", () => {
+    expect(() =>
+      // Deliberately bad input — cast through unknown to bypass the
+      // compile-time signature for the runtime guard.
+      MasterKeyFingerprint.fromMasterKey(
+        "not-a-buffer" as unknown as Uint8Array,
+      ),
+    ).toThrow(InvalidInputError);
+  });
+
+  it("rejects a Uint8Array shorter than 32 bytes", () => {
+    expect(() => MasterKeyFingerprint.fromMasterKey(new Uint8Array(16))).toThrow(
+      InvalidInputError,
+    );
+  });
+
+  it("rejects a Uint8Array longer than 32 bytes", () => {
+    expect(() => MasterKeyFingerprint.fromMasterKey(new Uint8Array(64))).toThrow(
+      InvalidInputError,
+    );
+  });
+});
+
+describe("MasterKeyFingerprint.fromHex", () => {
+  it("accepts the canonical lowercase-hex form", () => {
+    const fp = MasterKeyFingerprint.fromHex(ZERO_KEY_PREFIX);
+    expect(fp.toHex()).toBe(ZERO_KEY_PREFIX);
+  });
+
+  it("rejects uppercase hex", () => {
+    expect(() =>
+      MasterKeyFingerprint.fromHex(ZERO_KEY_PREFIX.toUpperCase()),
+    ).toThrow(InvalidInputError);
+  });
+
+  it("rejects shorter / longer / non-hex strings", () => {
+    expect(() => MasterKeyFingerprint.fromHex("")).toThrow(InvalidInputError);
+    expect(() => MasterKeyFingerprint.fromHex("deadbeef")).toThrow(
+      InvalidInputError,
+    );
+    expect(() =>
+      MasterKeyFingerprint.fromHex("zzzzzzzzzzzzzzzz"),
+    ).toThrow(InvalidInputError);
+    expect(() =>
+      MasterKeyFingerprint.fromHex("0123456789abcdef0"),
+    ).toThrow(InvalidInputError);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(() =>
+      MasterKeyFingerprint.fromHex(123 as unknown as string),
+    ).toThrow(InvalidInputError);
+  });
+});
+
+describe("MasterKeyFingerprint.equals", () => {
+  it("is reflexive", () => {
+    const k = new Uint8Array(32);
+    const fp = MasterKeyFingerprint.fromMasterKey(k);
+    expect(fp.equals(fp)).toBe(true);
+  });
+
+  it("is symmetric for the same key bytes", () => {
+    const k = new Uint8Array(32);
+    k.fill(0x11);
+    const a = MasterKeyFingerprint.fromMasterKey(k);
+    const b = MasterKeyFingerprint.fromMasterKey(k);
+    expect(a.equals(b)).toBe(true);
+    expect(b.equals(a)).toBe(true);
+  });
+
+  it("returns false for fingerprints of different keys", () => {
+    const k1 = new Uint8Array(32);
+    const k2 = new Uint8Array(32);
+    k2.fill(0xff);
+    const a = MasterKeyFingerprint.fromMasterKey(k1);
+    const b = MasterKeyFingerprint.fromMasterKey(k2);
+    expect(a.equals(b)).toBe(false);
+    expect(b.equals(a)).toBe(false);
+  });
+});
+
+describe("MasterKeyFingerprint — redaction on string/JSON serialisation", () => {
+  it("toString returns the redacted sentinel, never the hex", () => {
+    const key = new Uint8Array(32);
+    const fp = MasterKeyFingerprint.fromMasterKey(key);
+    expect(fp.toString()).toBe("<MasterKeyFingerprint:redacted>");
+    expect(fp.toString()).not.toContain(fp.toHex());
+  });
+
+  it("template literal hits toString (so it's redacted)", () => {
+    const key = new Uint8Array(32);
+    const fp = MasterKeyFingerprint.fromMasterKey(key);
+    const out = `fp=${fp}`;
+    expect(out).toBe("fp=<MasterKeyFingerprint:redacted>");
+    expect(out).not.toContain(fp.toHex());
+  });
+
+  it("JSON.stringify returns the redacted sentinel, not the hex", () => {
+    const key = new Uint8Array(32);
+    const fp = MasterKeyFingerprint.fromMasterKey(key);
+    const json = JSON.stringify({ fp });
+    expect(json).toBe('{"fp":"<MasterKeyFingerprint:redacted>"}');
+    expect(json).not.toContain(fp.toHex());
+  });
+});
+
+describe("MasterKeyFingerprint — class metadata helpers", () => {
+  it("lengthBytes() is 8", () => {
+    expect(MasterKeyFingerprint.lengthBytes()).toBe(8);
+  });
+
+  it("lengthHex() is 16", () => {
+    expect(MasterKeyFingerprint.lengthHex()).toBe(16);
+  });
+});


### PR DESCRIPTION
## Summary

Implementa el **paso 4** de la iteracion 2 ADR-005: audit log dedicado del modulo encryption con schema CONGELADO en `docs/12 §1.5.5` apendice Q4 (Phase-22 ACCEPTED, PR #72).

Cierra la recomendacion **O-ADR-005-Q4** del security-auditor (Phase-21).

## Schema (migracion 009)

`encryption_audit_log` con 8 columnas + index `idx_eal_ts` + **2 triggers append-only** (`eal_no_update` + `eal_no_delete` → `RAISE(ABORT, 'audit log is append-only')`).

Enum cerrado de **12 event types** (`KeyEnvelopeAdded`, `KeyEnvelopeRemoved`, `RekeyStarted/Completed/Failed`, `UnlockSucceeded/Failed`, `ExportKeyEmitted`, `KdfTimeoutExceeded`, `RECOVERY_SKIP_CHECKSUM`, `KeyValidatorMismatch`, `LEGACY_KEY_UNLOCK`) + **3 outcomes** (`SUCCESS | FAILURE | TIMEOUT`).

## VO `MasterKeyFingerprint` — defensas anti-leak

- Factory `fromMasterKey(bytes: Uint8Array)` computa `SHA-256(master)[:8 bytes]` (16 hex chars) via `@noble/hashes/sha2`.
- **`toString()` y `toJSON()` retornan sentinel `<MasterKeyFingerprint:redacted>`** → previene leak via template literal, `console.log`, `JSON.stringify`.
- `.toHex()` explicito requerido para acceder al hex real — debe permanecer SOLO en el adapter de audit log.
- Constant-time `equals`, defensive copy en factory, constructor privado.

## Adapter `SqliteEncryptionAuditRepository`

- Write-only by design (interface solo expone `append`).
- Prepared statement cacheado.
- Conversion UUID v7 string → 16-byte BLOB con defensive parsing.
- JSDoc explicito: "master_key_fingerprint local-only — NEVER serialise outside this adapter".

## Tests (31 totales)

- **10 integration tests** con SQLite real + MigrationsRunner real:
  - Persists all fields + null handling.
  - Trigger rejection UPDATE/DELETE caminando cause chain → mensaje exacto.
  - 12 event types + 3 outcomes roundtrip.
  - `EXPLAIN QUERY PLAN` verifica uso de `idx_eal_ts`.
  - 2 tests defence-in-depth para parsing UUID malformado.
- **21 unit tests** del VO:
  - Vectores conocidos: `SHA-256(0x00 × 32)[:8] = 66687aadf862bd77`, `SHA-256(0xff × 32)[:8] = af9613760f72635f`.
  - Redaccion en `toString`/`toJSON`/template literal contra string exacto.
  - Defensive copy: mutar input externo no afecta VO interno.
  - Constant-time `equals` reflexivo/simetrico.
  - Rechazo de input invalido en factories.

## Cobertura

| Archivo | Lines | Branches |
|---|---|---|
| event-id.ts | 100% | n/a |
| master-key-fingerprint.ts | 100% | 91.7% |
| sqlite-encryption-audit-repository.ts | 100% | 100% |

Por encima del threshold infrastructure 90%.

## Validadores pre-merge

- `clean-architecture-validator` → **APROBADO**
- `solid-validator` → **APROBADO**
- `security-auditor` → **APROBADO** con 1 follow-up no-bloqueante (**FP-001**: CI gate para `.toHex()` fuera del adapter; anotar en HANDOFF como `W-Q4-CI-GATE`)

## Decisiones tecnicas (vs spec del ADR)

1. Puerto out usa `.ts` (no `.port.ts`) siguiendo convencion del repo para repositorios (ver `secret-audit-repository.ts`).
2. `fromMasterKey(bytes: Uint8Array)` en vez de `Buffer` para consistencia con `MasterKey`.
3. `envelopeId: KeyId | null` (no `EnvelopeId` que no existe; la identidad del envelope ES `KeyId`).

## Test plan

- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` + `lint:tests` EXIT=0
- [x] `npm run validate:modules` EXIT=0
- [x] 10/10 integration tests pasan
- [x] 21/21 unit tests del VO pasan
- [ ] CI verde

## Follow-up tracked

**FP-001 / W-Q4-CI-GATE**: anadir CI gate (eslint rule `no-restricted-syntax` o script grep) que rechace `.toHex()` fuera de `sqlite-encryption-audit-repository.ts`. No bloquea merge; barrier procedural (JSDoc + audit) es solido en codigo. Anotar en HANDOFF Phase-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)