### PR TITLE
chore(logger): FU-A7-3 redact printableMasterKey in pino baseline

### DIFF
--- a/code/src/shared/infrastructure/logger/pino-logger.ts
+++ b/code/src/shared/infrastructure/logger/pino-logger.ts
@@ -40,6 +40,12 @@ export const DEFAULT_REDACT_PATHS: readonly string[] = Object.freeze([
   "derivedKey",
   "encryptionKey",
   "salt",
+  // FU-A7-3: defense in depth against a future regression that would
+  // log the human-readable Bech32 encoding of the master key
+  // (`recall export-key` payload). The CLI never logs the field today,
+  // but adding it to the baseline ensures even a misrouted child
+  // logger or a test-helper print cannot leak it.
+  "printableMasterKey",
   // Wildcard variants — pino supports the `*` glob.
   "*.passphrase",
   "*.password",
@@ -54,6 +60,7 @@ export const DEFAULT_REDACT_PATHS: readonly string[] = Object.freeze([
   "*.derivedKey",
   "*.encryptionKey",
   "*.salt",
+  "*.printableMasterKey",
   // Two-level wildcards for request-style envelopes (e.g. headers).
   "*.headers.authorization",
   "*.headers.cookie",

--- a/code/tests/unit/shared/infrastructure/logger/pino-logger.test.ts
+++ b/code/tests/unit/shared/infrastructure/logger/pino-logger.test.ts
@@ -87,6 +87,7 @@ describe("DEFAULT_REDACT_PATHS", () => {
       "derivedKey",
       "encryptionKey",
       "salt",
+      "printableMasterKey",
     ]) {
       expect(DEFAULT_REDACT_PATHS).toContain(k);
     }
@@ -107,6 +108,7 @@ describe("DEFAULT_REDACT_PATHS", () => {
       "*.derivedKey",
       "*.encryptionKey",
       "*.salt",
+      "*.printableMasterKey",
       "*.headers.authorization",
       "*.headers.cookie",
     ]) {
@@ -226,6 +228,10 @@ describe("PinoLogger.create — redaction (security-critical)", () => {
       derivedKey: "p11",
       encryptionKey: "p12",
       salt: "p13",
+      // FU-A7-3: Bech32 encoding of the master key (`recall export-key`)
+      // — never logged by the CLI today, but the redact baseline guards
+      // against a future regression.
+      printableMasterKey: "p14-recall1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw4",
     };
     log.info(sensitive, "with secrets");
     const text = joined(captured.stdout);


### PR DESCRIPTION
## Summary
- Adds `printableMasterKey` + `*.printableMasterKey` to `DEFAULT_REDACT_PATHS` in `code/src/shared/infrastructure/logger/pino-logger.ts`.
- Defense in depth: the CLI never logs the Bech32 encoding of the master key today, but the redact baseline now guards against a future regression.
- Two test updates in `code/tests/unit/shared/infrastructure/logger/pino-logger.test.ts` (documented top-level + wildcard contains; end-to-end redact assertion).

Closes follow-up tracked **FU-A7-3** (Phase-24 §6.29 A7 audit / HANDOFF §8).

## Test plan
- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` EXIT=0 (no warnings, max-warnings 0)
- [x] `npx vitest run tests/unit/shared/infrastructure/logger/pino-logger.test.ts` — 23/23 pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)