### PR TITLE
test(integration): F-A6-1 + FP-A5-3 tighten audit-log asserts

### DIFF
--- a/code/tests/integration/composition/add-key-facade.integration.test.ts
+++ b/code/tests/integration/composition/add-key-facade.integration.test.ts
@@ -125,15 +125,24 @@ describe("integration / composition / CliAddKeyFacadeAdapter — multi-key add",
     const labels = (config.key_envelopes ?? []).map((env) => env.label ?? null);
     expect(labels).toContain("alice@laptop");
 
-    // SQLite assertion: the audit log contains exactly two rows from
+    // SQLite assertion: the audit log contains EXACTLY two rows from
     // this run, joined on a single master-key fingerprint, both with
-    // outcome=SUCCESS. The `UnlockSucceeded` event covers BOTH the
-    // facade's pre-unlock call and the use case's own audit append;
-    // ADR-005 Q4 currently allows the double-unlock row pattern (the
-    // facade unlocks once via `UnlockEncryption.unlock(...)` then the
-    // use case appends its own `UnlockSucceeded` row). The assertions
-    // below tolerate the redundancy by checking for AT LEAST one
-    // `UnlockSucceeded` + exactly one `KeyEnvelopeAdded`.
+    // outcome=SUCCESS. Flow (verified post-investigation F-A6-1):
+    //   - `CliAddKeyFacadeAdapter.add(...)` calls only
+    //     `AddEnvelopeUseCase.addEnvelope(...)`. It does NOT perform a
+    //     separate pre-unlock at the facade boundary.
+    //   - `AddEnvelopeUseCase.addEnvelope(...)` orchestrates unlock +
+    //     wrap + persist + audit. The audit step (`appendAuditPair`)
+    //     emits EXACTLY one `UnlockSucceeded` + one `KeyEnvelopeAdded`
+    //     atomically inside one SQLite transaction.
+    //   - `UnlockEncryptionUseCase.unlock(...)` does NOT write to the
+    //     audit log; it emits the `EncryptionUnlocked` domain event
+    //     which is unsubscribed in production (no double-row source).
+    // The asserts therefore demand exact counts, not floors. Closes
+    // FP-A5-3 + F-A6-1 (HANDOFF §8): tightening the assert from
+    // `>= 1` to `=== 1` traps a future regression that would emit a
+    // stray `UnlockSucceeded` (e.g. wiring the unlock use case to a
+    // hypothetical "log every unlock" subscriber).
     const rows = ctx.database
       .prepare(
         `SELECT event_id, occurred_at_ms, event_type, envelope_id,
@@ -144,7 +153,7 @@ describe("integration / composition / CliAddKeyFacadeAdapter — multi-key add",
       .all() as readonly AuditRow[];
     const unlockRows = rows.filter((r) => r.event_type === "UnlockSucceeded");
     const addedRows = rows.filter((r) => r.event_type === "KeyEnvelopeAdded");
-    expect(unlockRows.length).toBeGreaterThanOrEqual(1);
+    expect(unlockRows.length).toBe(1);
     expect(addedRows.length).toBe(1);
     expect(addedRows[0]?.envelope_id).toBe(out.keyId);
     expect(addedRows[0]?.outcome).toBe("SUCCESS");

--- a/code/tests/integration/composition/rekey-facade.integration.test.ts
+++ b/code/tests/integration/composition/rekey-facade.integration.test.ts
@@ -164,10 +164,21 @@ describe("integration / composition / CliRekeyFacadeAdapter — multi-key rotati
     expect(config.key_envelopes?.[0]?.id).toBe(out.newKeyId);
     expect(config.key_envelopes?.[0]?.label).toBe("rotated@2026");
 
-    // SQLite assertion: the audit log contains the rotation chain.
-    // The add-key step contributed `UnlockSucceeded` +
-    // `KeyEnvelopeAdded` (handled by the add-key integration test);
-    // here we focus on the rekey-specific event types.
+    // SQLite assertion: the audit log contains the full rotation chain.
+    // Post-investigation (F-A6-1, HANDOFF §8) the contributors are
+    // exactly two: the prior `add-key` call and the `rekey` call.
+    // Neither the facade nor `UnlockEncryptionUseCase` emit extra
+    // `UnlockSucceeded` rows, so the totals are deterministic:
+    //   - add-key step:       1 UnlockSucceeded + 1 KeyEnvelopeAdded
+    //   - rekey step:         1 RekeyStarted + 1 UnlockSucceeded +
+    //                          1 KeyEnvelopeAdded + 2 KeyEnvelopeRemoved
+    //                          + 1 RekeyCompleted
+    //   - totals:             2 UnlockSucceeded + 2 KeyEnvelopeAdded +
+    //                          1 RekeyStarted + 1 RekeyCompleted +
+    //                          2 KeyEnvelopeRemoved
+    // Exact-count asserts trap a future regression that would emit a
+    // stray `UnlockSucceeded` (e.g. if the unlock use case starts
+    // writing directly to the audit log).
     const rows = ctx.database
       .prepare(
         `SELECT event_id, occurred_at_ms, event_type, envelope_id,
@@ -177,17 +188,17 @@ describe("integration / composition / CliRekeyFacadeAdapter — multi-key rotati
       )
       .all() as readonly AuditRow[];
 
+    const unlockRows = rows.filter((r) => r.event_type === "UnlockSucceeded");
     const rekeyStartedRows = rows.filter((r) => r.event_type === "RekeyStarted");
     const rekeyCompletedRows = rows.filter((r) => r.event_type === "RekeyCompleted");
     const removedRows = rows.filter((r) => r.event_type === "KeyEnvelopeRemoved");
     const addedRows = rows.filter((r) => r.event_type === "KeyEnvelopeAdded");
 
+    expect(unlockRows.length).toBe(2);
     expect(rekeyStartedRows.length).toBe(1);
     expect(rekeyCompletedRows.length).toBe(1);
     expect(removedRows.length).toBe(2);
-    // The KeyEnvelopeAdded count includes the add-key contribution
-    // PLUS the rekey contribution: AT LEAST 2.
-    expect(addedRows.length).toBeGreaterThanOrEqual(2);
+    expect(addedRows.length).toBe(2);
 
     // The trailing KeyEnvelopeAdded row carries the rekey's new
     // envelope id (rows are ordered by occurred_at_ms ASC, rowid ASC;


### PR DESCRIPTION
## Summary
Post-investigation of the \"double UnlockSucceeded\" comment in `add-key-facade.integration.test.ts`: the duplication never existed in production. The flow emits **exactly one** `UnlockSucceeded` row per `recall add-key`, and **exactly two** per `recall rekey` (one from the inner add-key step, one from the rekey step itself).

Tightening the asserts to exact counts (replacing `.toBeGreaterThanOrEqual(...)` with `.toBe(...)`) traps a future regression that would emit a stray `UnlockSucceeded` — for example if someone wires the unlock use case to a hypothetical \"log every unlock\" subscriber.

Closes follow-up tracked **FP-A5-3** + **F-A6-1** (Phase-24 §6.29 A5/A6 security audits / HANDOFF §8).

## Investigation notes (F-A6-1)
- `CliAddKeyFacadeAdapter.add(...)` calls ONLY `AddEnvelopeUseCase.addEnvelope(...)`. It does NOT perform a separate pre-unlock at the facade boundary (the prior JSDoc on the constructor was speculative).
- `AddEnvelopeUseCase.appendAuditPair(...)` (line 246-287) emits exactly 1 `UnlockSucceeded` + 1 `KeyEnvelopeAdded` atomically inside one SQLite transaction.
- `UnlockEncryptionUseCase` does NOT write to the audit log; it emits the `EncryptionUnlocked` domain event which has no production subscriber.
- `RekeyEncryptionUseCase.appendAuditChain(...)` emits 1 `RekeyStarted` + 1 `UnlockSucceeded` + 1 `KeyEnvelopeAdded` + N `KeyEnvelopeRemoved` + 1 `RekeyCompleted` per call.

## Changes
- `code/tests/integration/composition/add-key-facade.integration.test.ts`: `unlockRows.length >= 1` → `=== 1`; comment rewritten with the verified flow.
- `code/tests/integration/composition/rekey-facade.integration.test.ts`: added `unlockRows.length === 2` assert; `addedRows.length >= 2` → `=== 2`; comment rewritten with per-step row breakdown.

## Test plan
- [x] `npx vitest run tests/integration/composition/{add-key,rekey}-facade.integration.test.ts` — 4/4 pass.
- [x] `npm rebuild` after node version mismatch (no source change related).
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)