### PR TITLE
perf(database): W-3.3/3.4-PERF-M1/M2 cache prepared statements in SqliteDatabase

### DIFF
--- a/code/src/shared/infrastructure/database/sqlite-database.ts
+++ b/code/src/shared/infrastructure/database/sqlite-database.ts
@@ -207,6 +207,47 @@ class SqliteStatement implements PreparedStatement {
 export class SqliteDatabase implements DatabaseConnection {
   private isClosed: boolean;
 
+  /**
+   * Cache of `SqliteStatement` wrappers keyed by SQL source text
+   * (W-3.3-PERF-M1/M2 + W-3.4-PERF-M1/M2 — HANDOFF §8).
+   *
+   * Why: `DatabaseConnection.prepare(sql)` is invoked on every read /
+   * write of the hot paths in retrieval (recall, context, bumpUsage)
+   * and curator (decay, prune). Each call was previously
+   * (a) allocating a fresh `SqliteStatement` wrapper and (b) crossing
+   * the better-sqlite3 internal cache lookup. With ~50 unique SQL
+   * literals in the codebase and 100s of calls per recall pulse, the
+   * per-call overhead accumulated to a measurable cache-miss line in
+   * the Phase-5 performance audit.
+   *
+   * Mechanics:
+   * - The keys are the SQL strings as supplied by the caller. The
+   *   port docs (`docs/12 §1 perf`) state every adapter MUST use
+   *   prepared statements, and the codebase keeps the SQL in
+   *   `const SQL_*` literals — so the key set is bounded, stable
+   *   across the connection's lifetime, and naturally cacheable
+   *   without an eviction policy. Worst case the cache holds one
+   *   `SqliteStatement` per unique SQL string the adapter ever sees.
+   * - The cache is `Map<string, SqliteStatement>` (not WeakMap)
+   *   because the underlying `BetterSqlite3Statement` MUST stay
+   *   alive as long as the connection is open; we WANT to retain it.
+   * - The cache is invalidated on {@link close} so a closed
+   *   connection cannot resurrect a statement via cache lookup
+   *   (`assertOpen` already guards that, but the explicit clear is
+   *   defense in depth).
+   *
+   * Idempotence:
+   * - The port contract (`docs/12 §1 perf`, port JSDoc) says
+   *   `prepare` is idempotent for the same SQL string within the
+   *   same connection. Returning the cached instance ALSO returns
+   *   the same `===` identity to callers — which is a SUPERSET of
+   *   the contract (the docs explicitly say callers MUST NOT rely
+   *   on identity, but we're allowed to provide it). No caller in
+   *   the codebase compares statements by reference, so this is
+   *   safe.
+   */
+  private readonly statementCache = new Map<string, SqliteStatement>();
+
   private constructor(private readonly db: BetterSqlite3Database) {
     this.isClosed = false;
   }
@@ -290,13 +331,23 @@ export class SqliteDatabase implements DatabaseConnection {
 
   public prepare(sql: string): PreparedStatement {
     this.assertOpen("prepare");
+    // Fast path: return the cached wrapper if the SQL string was
+    // previously compiled on this connection. This avoids both the
+    // `new SqliteStatement(...)` allocation and the (cheap but
+    // non-zero) `this.db.prepare(...)` internal cache lookup of
+    // better-sqlite3. Closing the connection clears the cache.
+    const cached = this.statementCache.get(sql);
+    if (cached !== undefined) return cached;
+
     let stmt: BetterSqlite3Statement;
     try {
       stmt = this.db.prepare(sql);
     } catch (cause: unknown) {
       throw DatabaseError.prepareFailed(sql, cause);
     }
-    return new SqliteStatement(stmt, sql);
+    const wrapper = new SqliteStatement(stmt, sql);
+    this.statementCache.set(sql, wrapper);
+    return wrapper;
   }
 
   public exec(sql: string): void {
@@ -334,6 +385,12 @@ export class SqliteDatabase implements DatabaseConnection {
   public close(): void {
     if (this.isClosed) return;
     this.isClosed = true;
+    // Drop the statement cache. The wrapped `BetterSqlite3Statement`
+    // instances are no longer usable once the connection closes
+    // (better-sqlite3 throws "The database connection is not open"
+    // on any statement method); freeing the wrappers lets V8 reclaim
+    // their memory without waiting for the next GC cycle.
+    this.statementCache.clear();
     SqliteDatabase.safeClose(this.db);
   }
 

--- a/code/tests/unit/shared/infrastructure/database/sqlite-database.test.ts
+++ b/code/tests/unit/shared/infrastructure/database/sqlite-database.test.ts
@@ -433,6 +433,82 @@ describe("SqliteDatabase.close", () => {
   });
 });
 
+describe("SqliteDatabase prepare cache (W-3.3 + W-3.4 PERF-M1/M2)", () => {
+  it("returns the SAME wrapper for the same SQL text across calls", async () => {
+    const logger = newLogger();
+    const db = await SqliteDatabase.open({
+      path: ":memory:",
+      logger,
+      loadVectorExtension: false,
+    });
+    try {
+      db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
+      const a = db.prepare("INSERT INTO t (name) VALUES (?)");
+      const b = db.prepare("INSERT INTO t (name) VALUES (?)");
+      // Same SQL string → cached wrapper returned, identity preserved.
+      // Note: the port contract says callers MUST NOT rely on `===`
+      // identity, but the adapter is allowed to provide it. This test
+      // pins the cache behavior so a future refactor that breaks the
+      // cache is observable here.
+      expect(a).toBe(b);
+      // Different SQL → fresh wrapper.
+      const c = db.prepare("SELECT name FROM t WHERE id = ?");
+      expect(c).not.toBe(a);
+      // Each cached wrapper still operates correctly.
+      a.run("first");
+      const row = c.get(1);
+      expect(row).toEqual({ name: "first" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("the cache survives many distinct SQL strings without leaks across queries", async () => {
+    const logger = newLogger();
+    const db = await SqliteDatabase.open({
+      path: ":memory:",
+      logger,
+      loadVectorExtension: false,
+    });
+    try {
+      db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
+      // 30 distinct SQL strings — each stays in cache; reusing any of
+      // them returns the same wrapper.
+      const seen: unknown[] = [];
+      for (let i = 0; i < 30; i++) {
+        const stmt = db.prepare(`SELECT ${String(i)} AS v`);
+        seen.push(stmt);
+      }
+      // Re-request each by the same SQL — must return the cached one.
+      for (let i = 0; i < 30; i++) {
+        const stmt2 = db.prepare(`SELECT ${String(i)} AS v`);
+        expect(stmt2).toBe(seen[i]);
+        expect(stmt2.get()).toEqual({ v: i });
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("closing the connection invalidates the cache (new prepare on a closed db throws)", async () => {
+    const logger = newLogger();
+    const db = await SqliteDatabase.open({
+      path: ":memory:",
+      logger,
+      loadVectorExtension: false,
+    });
+    db.exec("CREATE TABLE t (k INTEGER)");
+    const before = db.prepare("SELECT k FROM t");
+    expect(before.all()).toEqual([]);
+    db.close();
+    // After close, a prepare for the SAME SQL must NOT return the
+    // cached wrapper (assertOpen would still throw first, but this
+    // pins the policy that closed connections cannot resurrect a
+    // statement from the cache).
+    expect(() => db.prepare("SELECT k FROM t")).toThrow(DatabaseError);
+  });
+});
+
 describe("SqliteDatabase encryption (SQLCipher)", () => {
   let tmp: string;
 


### PR DESCRIPTION
## Summary
Adds a per-connection `Map<string, SqliteStatement>` to `SqliteDatabase.prepare(sql)`. The hot paths in retrieval (recall, context, bumpUsage) and curator (decay, prune) no longer pay the `new SqliteStatement(...)` allocation per call. The cache:
- is keyed by SQL source text;
- is populated lazily on the first prepare for a given SQL string;
- is cleared on `close()`;
- holds at most one wrapper per literal SQL (~50 today, bounded).

Closes follow-up tracked **W-3.3-PERF-M1/M2** + **W-3.4-PERF-M1/M2** at the implementation level (Phase-5 performance audit / HANDOFF §8).

## Why this is safe
- `SqliteStatement` is stateless beyond two private readonly fields (the wrapped `BetterSqlite3Statement` + the source SQL). Returning the same wrapper across `prepare(sql)` calls preserves the port contract — the port docs explicitly say callers MUST NOT rely on `===` identity, so providing identity is a SUPERSET of the contract.
- Closing the connection clears the cache before `safeClose(this.db)`. Any subsequent `prepare(sql)` first hits `assertOpen` and throws `DatabaseError.connectionClosed`, so a closed connection cannot resurrect a statement.
- Existing prepare/exec/transaction tests pass unchanged (39 in `sqlite-database.test.ts`, 640 in retrieval + curator suites).

## What this changes
- The `db.prepare(sql)` call into better-sqlite3 itself is already cache-backed internally (since v8.4.0). The wall-clock saving per call is dominated by the `new SqliteStatement(...)` allocation + wrapper closure setup. On a 100-row recall pulse with ~5 unique queries, that's ~100 fewer wrapper allocations per pulse.

## Benchmark validation
Deferred to a separate follow-up commit per HANDOFF §6.30 plan (\"benchmark previo + cache implementation + benchmark posterior\"). The change is **correctness-preserving** — if the benchmark shows no measurable gain the cache stays as a small memory cost with no regression.

## Files
- `code/src/shared/infrastructure/database/sqlite-database.ts` — added `statementCache` field, cache check on `prepare`, cache clear on `close`.
- `code/tests/unit/shared/infrastructure/database/sqlite-database.test.ts` — 3 new tests pinning the cache behavior (same SQL → same wrapper; many distinct strings cached; close() invalidates).

## Test plan
- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` EXIT=0
- [x] `npx vitest run tests/unit/shared/infrastructure/database` — 39/39 pass (3 new cache tests).
- [x] `npx vitest run tests/unit/retrieval tests/unit/curator tests/integration/retrieval tests/integration/curator` — 640/640 pass.
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)