### PR TITLE
feat(workspace,encryption): FU-A7-2 surface last_export_at en recall health

### DIFF
--- a/code/src/composition/container.ts
+++ b/code/src/composition/container.ts
@@ -88,6 +88,7 @@ import {
 import { AddEnvelopeUseCase } from "../modules/encryption/application/use-cases/add-envelope.use-case.ts";
 import { ExportMasterKeyUseCase } from "../modules/encryption/application/use-cases/export-master-key.use-case.ts";
 import { RekeyEncryptionUseCase } from "../modules/encryption/application/use-cases/rekey-encryption.use-case.ts";
+import { SqliteEncryptionAuditProbe } from "../modules/encryption/infrastructure/persistence/sqlite-encryption-audit-probe.ts";
 import { SqliteEncryptionAuditRepository } from "../modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts";
 import {
   DestroyEncryptionFacadeAdapter,
@@ -254,7 +255,12 @@ export function buildContainer(options: ContainerOptions): Container {
     encryption.destroyEncryption,
   );
 
-  // Step 5 — workspace.
+  // Step 5 — workspace. The encryption audit probe (FU-A7-2) reads
+  // `last_export_at` from `encryption_audit_log` and surfaces it via
+  // `recall health`. Wired here because the container is the first
+  // composition layer with a live `DatabaseConnection` AND the
+  // workspace `HealthCheckUseCase` needs the probe at construction.
+  const encryptionAuditProbe = new SqliteEncryptionAuditProbe(options.database);
   const workspace = buildWorkspaceWiring({
     logger,
     clock: shared.clock,
@@ -266,6 +272,7 @@ export function buildContainer(options: ContainerOptions): Container {
     unlockEncryptionFacade,
     lockEncryptionFacade,
     destroyEncryptionFacade,
+    encryptionAuditProbe,
   });
 
   // Step 6 — workspace id resolution. The memory + curator wirings

--- a/code/src/composition/wiring/workspace-wiring.ts
+++ b/code/src/composition/wiring/workspace-wiring.ts
@@ -16,6 +16,7 @@
 
 import type { Embedder as RawEmbedder } from "../../shared/application/ports/embedder.port.ts";
 import type { Clock } from "../../shared/application/ports/clock.port.ts";
+import type { EncryptionAuditProbe } from "../../shared/application/ports/encryption-audit-probe.port.ts";
 import type { EventPublisher } from "../../shared/application/ports/event-publisher.port.ts";
 import type { IdGenerator } from "../../shared/application/ports/id-generator.port.ts";
 import type { Logger } from "../../shared/application/ports/logger.port.ts";
@@ -87,6 +88,14 @@ export interface WorkspaceWiringOptions {
   readonly unlockEncryptionFacade: UnlockEncryptionFacade;
   readonly lockEncryptionFacade: LockEncryptionFacade;
   readonly destroyEncryptionFacade: DestroyEncryptionFacade;
+  /**
+   * Optional probe over `encryption_audit_log` used by
+   * `HealthCheckUseCase` to surface `last_export_at` (FU-A7-2). The
+   * container wires `SqliteEncryptionAuditProbe(options.database)`;
+   * tests that do not exercise the encryption module pass `null` and
+   * the health check skips the entry.
+   */
+  readonly encryptionAuditProbe?: EncryptionAuditProbe | null;
 }
 
 /**
@@ -174,6 +183,7 @@ export function buildWorkspaceWiring(
     databaseBootstrap,
     embedderProbe,
     options.logger,
+    options.encryptionAuditProbe ?? null,
   );
 
   return {

--- a/code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-probe.ts
+++ b/code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-probe.ts
@@ -1,0 +1,66 @@
+import type { DatabaseConnection } from "../../../../shared/application/ports/database-connection.port.ts";
+import type { EncryptionAuditProbe } from "../../../../shared/application/ports/encryption-audit-probe.port.ts";
+import { Timestamp } from "../../../../shared/domain/value-objects/timestamp.ts";
+
+/**
+ * Returns the most recent `ExportKeyEmitted` row with `outcome=SUCCESS`.
+ * Ordered DESC on the `occurred_at_ms` index (`idx_eal_ts`) so the
+ * lookup is O(log n) on the table.
+ *
+ * Why filtered on `outcome=SUCCESS`:
+ * - `ExportKeyEmitted` rows are only emitted on success today; a
+ *   future use case that records `FAILURE` outcomes for export
+ *   attempts SHOULD use a distinct event-type. Filtering defensively
+ *   keeps the probe's contract stable: it returns the moment a real
+ *   `export-key` payload was rendered, not the moment one was
+ *   attempted.
+ */
+const SQL_LAST_SUCCESSFUL_EXPORT = `
+SELECT occurred_at_ms
+FROM encryption_audit_log
+WHERE event_type = 'ExportKeyEmitted'
+  AND outcome    = 'SUCCESS'
+ORDER BY occurred_at_ms DESC
+LIMIT 1
+`.trim();
+
+/**
+ * Adapter that fulfils the `EncryptionAuditProbe` port via the SQLite
+ * `encryption_audit_log` table (migration 009).
+ *
+ * Closes follow-up tracked FU-A7-2 (HANDOFF §8): the `recall health`
+ * CLI surfaces `last_export_at` so the user can detect an export
+ * payload that did NOT originate from them — defense in depth against
+ * an unauthorised terminal that ran `recall export-key`.
+ *
+ * Why this adapter is read-only:
+ * - The append-only invariant of the audit log lives at the persistence
+ *   layer (triggers `eal_no_update` / `eal_no_delete`). This probe
+ *   issues only SELECT statements; the triggers do not apply.
+ * - The probe deliberately does NOT join on `master_key_fp` or
+ *   `envelope_id`. The only field it surfaces is `occurred_at_ms`,
+ *   which is non-secret by construction (an opaque epoch integer).
+ *
+ * Why the adapter lives in `encryption/infrastructure/`:
+ * - The SQL it issues is encryption-module-specific (it knows the
+ *   table name and the `ExportKeyEmitted` event-type enum). The port
+ *   it implements lives in `shared/` so the workspace use case can
+ *   import it without crossing the modularity boundary.
+ *
+ * Concurrency:
+ * - Better-sqlite3 is synchronous and serial per connection; this
+ *   probe holds no shared mutable state. Safe to call from any
+ *   request path that already owns the `DatabaseConnection`.
+ */
+export class SqliteEncryptionAuditProbe implements EncryptionAuditProbe {
+  public constructor(private readonly db: DatabaseConnection) {}
+
+  public lastExportAt(): Promise<Timestamp | null> {
+    const stmt = this.db.prepare(SQL_LAST_SUCCESSFUL_EXPORT);
+    const row = stmt.get() as { occurred_at_ms: number } | undefined;
+    if (row === undefined) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(Timestamp.fromEpochMs(row.occurred_at_ms));
+  }
+}

--- a/code/src/modules/workspace/application/use-cases/health-check.use-case.ts
+++ b/code/src/modules/workspace/application/use-cases/health-check.use-case.ts
@@ -1,3 +1,4 @@
+import type { EncryptionAuditProbe } from "../../../../shared/application/ports/encryption-audit-probe.port.ts";
 import type { Logger } from "../../../../shared/application/ports/logger.port.ts";
 import { WorkspaceMode } from "../../domain/value-objects/workspace-mode.ts";
 import type {
@@ -47,6 +48,20 @@ export class HealthCheckUseCase implements HealthCheck {
     private readonly databaseBootstrap: DatabaseBootstrap,
     private readonly embedderProbe: EmbedderProbe,
     private readonly logger: Logger,
+    /**
+     * Optional probe for the `encryption_audit_log` table (migration
+     * 009). When wired by the composition root, the use case appends
+     * an `encryption.last_export_at` entry surfacing the timestamp of
+     * the most recent `ExportKeyEmitted` row. When `null`, the entry
+     * is `skipped` with an explanatory message.
+     *
+     * Closes follow-up tracked FU-A7-2 (HANDOFF §8): the CLI's
+     * `recall health` surfaces `last_export_at` so the user can
+     * detect an export that did not originate from them (defense in
+     * depth against an unauthorised terminal running `recall
+     * export-key`).
+     */
+    private readonly encryptionAuditProbe: EncryptionAuditProbe | null = null,
   ) {}
 
   public async check(input: HealthCheckInput): Promise<HealthCheckOutput> {
@@ -80,6 +95,7 @@ export class HealthCheckUseCase implements HealthCheck {
         skipped("migrations.current", "workspace not found"),
         skipped("embedder.loadable", "workspace not found"),
         skipped("gitignore.consistent", "workspace not found"),
+        skipped("encryption.last_export_at", "workspace not found"),
       );
       return finish(checks);
     }
@@ -118,6 +134,7 @@ export class HealthCheckUseCase implements HealthCheck {
         skipped("migrations.current", "config not parseable"),
         skipped("embedder.loadable", "config not parseable"),
         skipped("gitignore.consistent", "config not parseable"),
+        skipped("encryption.last_export_at", "config not parseable"),
       );
       return finish(checks);
     }
@@ -182,6 +199,47 @@ export class HealthCheckUseCase implements HealthCheck {
         "deferred to v0.5 (TODO-WS-1); call recall mode <current> to self-heal",
       ),
     );
+
+    // 7. encryption.last_export_at — surfaces the timestamp of the most
+    //    recent `recall export-key` invocation so the user can detect
+    //    an export that did not originate from them. Only meaningful in
+    //    `encrypted` mode; skipped otherwise (the encryption_audit_log
+    //    table exists in every mode but is naturally empty for shared /
+    //    private workspaces). Failures of the probe surface as `fail`
+    //    so a corrupted audit table is observable.
+    if (parsedMode !== "encrypted") {
+      checks.push(
+        skipped(
+          "encryption.last_export_at",
+          `not applicable to mode=${parsedMode}`,
+        ),
+      );
+    } else if (this.encryptionAuditProbe === null) {
+      checks.push(
+        skipped(
+          "encryption.last_export_at",
+          "encryption audit probe not wired (composition root)",
+        ),
+      );
+    } else {
+      try {
+        const lastExportAt = await this.encryptionAuditProbe.lastExportAt();
+        checks.push({
+          id: "encryption.last_export_at",
+          status: "pass",
+          message:
+            lastExportAt === null
+              ? "no recall export-key invocation recorded"
+              : `last export at ${new Date(lastExportAt.toEpochMs()).toISOString()}`,
+        });
+      } catch (err: unknown) {
+        checks.push({
+          id: "encryption.last_export_at",
+          status: "fail",
+          message: `encryption audit probe threw: ${HealthCheckUseCase.errorMessage(err)}`,
+        });
+      }
+    }
 
     this.logger.debug(
       { checkCount: checks.length },

--- a/code/src/shared/application/ports/encryption-audit-probe.port.ts
+++ b/code/src/shared/application/ports/encryption-audit-probe.port.ts
@@ -1,0 +1,46 @@
+import type { Timestamp } from "../../domain/value-objects/timestamp.ts";
+
+/**
+ * Driven (output) port that surfaces small read-only projections of
+ * `encryption_audit_log` to consumers outside the encryption module.
+ *
+ * **Why a dedicated port and not `EncryptionAuditLogRepository`:**
+ * - The repository port in `modules/encryption/domain/repositories/`
+ *   is intentionally write-only at the domain boundary: it exposes
+ *   only `append(event)`. Adding read methods there would force every
+ *   future implementer to provide them, and worse, the read methods
+ *   would have privileged access to `masterKeyFingerprint` values
+ *   which the contract forbids surfacing.
+ * - This port is the boundary used by the workspace `HealthCheck`
+ *   use case (cross-module via `shared/`, see ADR-001 in
+ *   `docs/12-lineamientos-arquitectura.md` §1.5). Living here means
+ *   neither the workspace module imports from encryption, nor
+ *   encryption from workspace; the composition root wires the
+ *   adapter once.
+ *
+ * Contract:
+ * - Implementations MUST NOT return `master_key_fp` values from any
+ *   method on this port. Even projected fields stay redacted-by-default.
+ * - Implementations MAY assume the `encryption_audit_log` table exists
+ *   (migration 009 runs unconditionally) and is append-only.
+ * - Methods MUST be safe to call on every workspace mode. For
+ *   `shared` / `private` workspaces the table is naturally empty, so
+ *   every method returns `null` / `0` / equivalent. Callers do NOT
+ *   need to gate on workspace mode before calling.
+ *
+ * Closes follow-up tracked FU-A7-2 (HANDOFF §8): the CLI's
+ * `recall health` surfaces `last_export_at` so the user can detect
+ * an export that did not originate from them (defense in depth
+ * against unauthorised terminal access).
+ */
+export interface EncryptionAuditProbe {
+  /**
+   * Returns the timestamp of the most recent successful
+   * `ExportKeyEmitted` audit row for this workspace, or `null` if no
+   * `recall export-key` invocation has ever succeeded.
+   *
+   * The probe ignores `FAILURE` outcomes — those are captured by
+   * `UnlockFailed` rows with `actorHint=cli:export-key` instead.
+   */
+  lastExportAt(): Promise<Timestamp | null>;
+}

--- a/code/src/shared/application/ports/index.ts
+++ b/code/src/shared/application/ports/index.ts
@@ -62,3 +62,5 @@ export type { IdGenerator } from "./id-generator.port.ts";
 export type { Embedder, RawEmbedding } from "./embedder.port.ts";
 
 export type { EventPublisher } from "./event-publisher.port.ts";
+
+export type { EncryptionAuditProbe } from "./encryption-audit-probe.port.ts";

--- a/code/tests/integration/encryption/sqlite-encryption-audit-probe.integration.test.ts
+++ b/code/tests/integration/encryption/sqlite-encryption-audit-probe.integration.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Integration test — `SqliteEncryptionAuditProbe` (FU-A7-2).
+ *
+ * Drives the adapter against a real on-disk SQLite database after
+ * running every migration (so `encryption_audit_log` is present with
+ * its append-only triggers + the `idx_eal_ts` index). Verifies:
+ *
+ *   - `lastExportAt()` returns `null` on an empty table.
+ *   - `lastExportAt()` returns the latest `ExportKeyEmitted` timestamp
+ *     when one or more rows are present.
+ *   - `FAILURE` rows are ignored (the probe filters on
+ *     `outcome = 'SUCCESS'`).
+ *   - Other event-type rows (`UnlockSucceeded`, `UnlockFailed`, ...)
+ *     do NOT influence the result.
+ *
+ * Pattern mirrors `sqlite-encryption-audit-repository.integration.test`
+ * (same migrations dir, same beforeEach/afterEach, same VO fixtures).
+ */
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { EventId } from "../../../src/modules/encryption/domain/value-objects/event-id.ts";
+import { SqliteEncryptionAuditProbe } from "../../../src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-probe.ts";
+import { SqliteEncryptionAuditRepository } from "../../../src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-repository.ts";
+import { NonEmptyString } from "../../../src/shared/domain/value-objects/non-empty-string.ts";
+import { Timestamp } from "../../../src/shared/domain/value-objects/timestamp.ts";
+import {
+  SqliteDatabase,
+  type SqliteDatabaseOpenOptions,
+} from "../../../src/shared/infrastructure/database/sqlite-database.ts";
+import { MigrationsRunner } from "../../../src/shared/infrastructure/database/migrations-runner.ts";
+import { RecordingLogger } from "../../_fixtures/silent-logger.ts";
+
+const EVENT_ID_1 = "019e1de3-6015-76e1-a3aa-e882b6a6809f";
+const EVENT_ID_2 = "019e1de3-6017-71b6-919d-321d064575da";
+const EVENT_ID_3 = "019e1de3-6017-71b6-919d-35204ca8768e";
+const EVENT_ID_4 = "019e1de3-6017-71b6-919d-3a3c178f1a0f";
+
+const MIGRATIONS_DIR = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "..",
+  "..",
+  "..",
+  "migrations",
+);
+
+let tmpDir: string;
+let database: SqliteDatabase;
+let repo: SqliteEncryptionAuditRepository;
+let probe: SqliteEncryptionAuditProbe;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "recall-eap-"));
+  const dbPath = path.join(tmpDir, "audit.db");
+  const logger = new RecordingLogger();
+  const openOptions: SqliteDatabaseOpenOptions = {
+    path: dbPath,
+    loadVectorExtension: true,
+    logger,
+  };
+  database = await SqliteDatabase.open(openOptions);
+  const runner = new MigrationsRunner(logger);
+  await runner.run(database, MIGRATIONS_DIR);
+  repo = new SqliteEncryptionAuditRepository(database);
+  probe = new SqliteEncryptionAuditProbe(database);
+});
+
+afterEach(async () => {
+  try {
+    database.close();
+  } catch {
+    // already closed
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+});
+
+const actor = NonEmptyString.create("cli:export-key", "actor_hint");
+
+describe("SqliteEncryptionAuditProbe.lastExportAt", () => {
+  it("returns null when the table is empty", async () => {
+    const result = await probe.lastExportAt();
+    expect(result).toBeNull();
+  });
+
+  it("returns the timestamp of the only ExportKeyEmitted row", async () => {
+    const exportedAt = Timestamp.fromEpochMs(1_745_000_000_000);
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_1),
+      occurredAt: exportedAt,
+      eventType: "ExportKeyEmitted",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "SUCCESS",
+      detailJson: null,
+    });
+
+    const result = await probe.lastExportAt();
+    expect(result?.toEpochMs()).toBe(exportedAt.toEpochMs());
+  });
+
+  it("returns the MOST RECENT ExportKeyEmitted across multiple rows", async () => {
+    const earlier = Timestamp.fromEpochMs(1_745_000_000_000);
+    const later = Timestamp.fromEpochMs(1_745_000_100_000);
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_1),
+      occurredAt: earlier,
+      eventType: "ExportKeyEmitted",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "SUCCESS",
+      detailJson: null,
+    });
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_2),
+      occurredAt: later,
+      eventType: "ExportKeyEmitted",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "SUCCESS",
+      detailJson: null,
+    });
+
+    const result = await probe.lastExportAt();
+    expect(result?.toEpochMs()).toBe(later.toEpochMs());
+  });
+
+  it("ignores FAILURE-outcome ExportKeyEmitted rows (defensive filter)", async () => {
+    // The current export flow only emits SUCCESS rows, but the probe
+    // SHOULD filter defensively so a future regression that records
+    // FAILURE outcomes does not poison the health check.
+    const failureAt = Timestamp.fromEpochMs(1_745_000_500_000);
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_3),
+      occurredAt: failureAt,
+      eventType: "ExportKeyEmitted",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "FAILURE",
+      detailJson: { reason: "synthetic-test" },
+    });
+
+    const result = await probe.lastExportAt();
+    expect(result).toBeNull();
+  });
+
+  it("ignores other event types (UnlockSucceeded / UnlockFailed / KeyEnvelopeAdded)", async () => {
+    const t = Timestamp.fromEpochMs(1_745_000_700_000);
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_1),
+      occurredAt: t,
+      eventType: "UnlockSucceeded",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "SUCCESS",
+      detailJson: null,
+    });
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_2),
+      occurredAt: t,
+      eventType: "UnlockFailed",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "FAILURE",
+      detailJson: { reason: "invalid-passphrase" },
+    });
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_3),
+      occurredAt: t,
+      eventType: "KeyEnvelopeAdded",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "SUCCESS",
+      detailJson: null,
+    });
+
+    const result = await probe.lastExportAt();
+    expect(result).toBeNull();
+  });
+
+  it("returns the latest SUCCESS export even when newer FAILURE rows exist", async () => {
+    const successAt = Timestamp.fromEpochMs(1_745_000_900_000);
+    const laterFailureAt = Timestamp.fromEpochMs(1_745_001_000_000);
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_1),
+      occurredAt: successAt,
+      eventType: "ExportKeyEmitted",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "SUCCESS",
+      detailJson: null,
+    });
+    await repo.append({
+      eventId: EventId.from(EVENT_ID_4),
+      occurredAt: laterFailureAt,
+      eventType: "ExportKeyEmitted",
+      envelopeId: null,
+      masterKeyFingerprint: null,
+      actorHint: actor,
+      outcome: "FAILURE",
+      detailJson: { reason: "synthetic-test" },
+    });
+
+    const result = await probe.lastExportAt();
+    expect(result?.toEpochMs()).toBe(successAt.toEpochMs());
+  });
+});

--- a/code/tests/unit/workspace/application/use-cases/health-check.use-case.test.ts
+++ b/code/tests/unit/workspace/application/use-cases/health-check.use-case.test.ts
@@ -14,12 +14,51 @@ import type {
   DetectWorkspaceInput,
   DetectWorkspaceOutput,
 } from "../../../../../src/modules/workspace/application/ports/in/detect-workspace.port.ts";
+import type { EncryptionAuditProbe } from "../../../../../src/shared/application/ports/encryption-audit-probe.port.ts";
 import {
   FakeFilesystem,
   SilentLogger,
   StubDatabaseBootstrap,
   StubEmbedderProbe,
 } from "../../../../fixtures/workspace-fixtures.ts";
+
+/**
+ * Minimal `EncryptionAuditProbe` stub used by FU-A7-2 tests below.
+ * Returns the configured `outcome`. When the constructor receives a
+ * `throws` value, every `lastExportAt()` call rejects with it so the
+ * use case's catch path is exercised.
+ */
+class StubEncryptionAuditProbe implements EncryptionAuditProbe {
+  public constructor(
+    private readonly outcome: Timestamp | null,
+    private readonly throws: unknown = null,
+  ) {}
+  public lastExportAt(): Promise<Timestamp | null> {
+    if (this.throws !== null) {
+      return Promise.reject(
+        this.throws instanceof Error ? this.throws : new Error(String(this.throws)),
+      );
+    }
+    return Promise.resolve(this.outcome);
+  }
+}
+
+/**
+ * Convenience factory: builds a workspace aggregate with the given mode
+ * label (the rest of the test below only needs the mode for the
+ * `encryption.last_export_at` branching).
+ */
+function buildWorkspaceWithMode(mode: WorkspaceMode): Workspace {
+  const cfg = WorkspaceConfig.create({
+    schemaVersion: "1.0.0",
+    workspaceId: WorkspaceId.from(FIXED_UUID),
+    displayName: DisplayName.create("T"),
+    mode,
+    embedder: EmbedderSpec.create({ provider: "fastembed", model: "BGESmallEN15" }),
+    createdAt: Timestamp.fromEpochMs(0),
+  });
+  return Workspace.rehydrate(cfg);
+}
 
 const ROOT = WorkspacePath.create("/tmp/host");
 const FIXED_UUID = "00000000-0000-7000-8000-000000000001";
@@ -331,5 +370,180 @@ describe("HealthCheckUseCase", () => {
     const e = out.checks[0];
     expect(e?.status).toBe("fail");
     expect(e?.message).toContain("string-not-error");
+  });
+});
+
+describe("HealthCheckUseCase — encryption.last_export_at (FU-A7-2)", () => {
+  it("encrypted mode + probe returns null → pass with 'no recall export-key' message", async () => {
+    const fs = new FakeFilesystem();
+    const detect = new StubDetect({
+      found: true,
+      workspace: buildWorkspaceWithMode(WorkspaceMode.encryptedMode()),
+      rootPath: ROOT,
+    });
+    const db = new StubDatabaseBootstrap();
+    db.probeResult = { openable: true, schemaVersion: 9 };
+    const embedder = new StubEmbedderProbe();
+    embedder.outcome = { ok: true, dimension: 384, message: "ok" };
+    const auditProbe = new StubEncryptionAuditProbe(null);
+
+    const uc = new HealthCheckUseCase(
+      detect,
+      fs,
+      db,
+      embedder,
+      new SilentLogger(),
+      auditProbe,
+    );
+    const out = await uc.check({ rootPath: ROOT });
+    const entry = out.checks.find((c) => c.id === "encryption.last_export_at");
+    expect(entry?.status).toBe("pass");
+    expect(entry?.message).toContain("no recall export-key invocation");
+    expect(out.healthy).toBe(true);
+  });
+
+  it("encrypted mode + probe returns timestamp → pass with ISO 8601 message", async () => {
+    const fs = new FakeFilesystem();
+    const detect = new StubDetect({
+      found: true,
+      workspace: buildWorkspaceWithMode(WorkspaceMode.encryptedMode()),
+      rootPath: ROOT,
+    });
+    const db = new StubDatabaseBootstrap();
+    db.probeResult = { openable: true, schemaVersion: 9 };
+    const embedder = new StubEmbedderProbe();
+    embedder.outcome = { ok: true, dimension: 384, message: "ok" };
+    const exportedAt = Timestamp.fromEpochMs(1_700_000_900_000);
+    const auditProbe = new StubEncryptionAuditProbe(exportedAt);
+
+    const uc = new HealthCheckUseCase(
+      detect,
+      fs,
+      db,
+      embedder,
+      new SilentLogger(),
+      auditProbe,
+    );
+    const out = await uc.check({ rootPath: ROOT });
+    const entry = out.checks.find((c) => c.id === "encryption.last_export_at");
+    expect(entry?.status).toBe("pass");
+    expect(entry?.message).toContain(
+      new Date(exportedAt.toEpochMs()).toISOString(),
+    );
+    expect(out.healthy).toBe(true);
+  });
+
+  it("encrypted mode + probe throws → fail (corrupted audit-log surfaces, healthy=false)", async () => {
+    const fs = new FakeFilesystem();
+    const detect = new StubDetect({
+      found: true,
+      workspace: buildWorkspaceWithMode(WorkspaceMode.encryptedMode()),
+      rootPath: ROOT,
+    });
+    const db = new StubDatabaseBootstrap();
+    db.probeResult = { openable: true, schemaVersion: 9 };
+    const embedder = new StubEmbedderProbe();
+    embedder.outcome = { ok: true, dimension: 384, message: "ok" };
+    const auditProbe = new StubEncryptionAuditProbe(
+      null,
+      new Error("encryption_audit_log table corrupted"),
+    );
+
+    const uc = new HealthCheckUseCase(
+      detect,
+      fs,
+      db,
+      embedder,
+      new SilentLogger(),
+      auditProbe,
+    );
+    const out = await uc.check({ rootPath: ROOT });
+    const entry = out.checks.find((c) => c.id === "encryption.last_export_at");
+    expect(entry?.status).toBe("fail");
+    expect(entry?.message).toContain("encryption_audit_log table corrupted");
+    expect(out.healthy).toBe(false);
+  });
+
+  it("shared mode → skipped (probe wired but not applicable)", async () => {
+    const fs = new FakeFilesystem();
+    const detect = new StubDetect({
+      found: true,
+      workspace: buildWorkspaceWithMode(WorkspaceMode.sharedMode()),
+      rootPath: ROOT,
+    });
+    const db = new StubDatabaseBootstrap();
+    db.probeResult = { openable: true, schemaVersion: 9 };
+    const embedder = new StubEmbedderProbe();
+    embedder.outcome = { ok: true, dimension: 384, message: "ok" };
+    const auditProbe = new StubEncryptionAuditProbe(
+      Timestamp.fromEpochMs(1_700_000_900_000),
+    );
+
+    const uc = new HealthCheckUseCase(
+      detect,
+      fs,
+      db,
+      embedder,
+      new SilentLogger(),
+      auditProbe,
+    );
+    const out = await uc.check({ rootPath: ROOT });
+    const entry = out.checks.find((c) => c.id === "encryption.last_export_at");
+    expect(entry?.status).toBe("skipped");
+    expect(entry?.message).toContain("not applicable to mode=shared");
+  });
+
+  it("private mode → skipped", async () => {
+    const fs = new FakeFilesystem();
+    const detect = new StubDetect({
+      found: true,
+      workspace: buildWorkspaceWithMode(WorkspaceMode.privateMode()),
+      rootPath: ROOT,
+    });
+    const db = new StubDatabaseBootstrap();
+    db.probeResult = { openable: true, schemaVersion: 9 };
+    const embedder = new StubEmbedderProbe();
+    embedder.outcome = { ok: true, dimension: 384, message: "ok" };
+    const auditProbe = new StubEncryptionAuditProbe(null);
+
+    const uc = new HealthCheckUseCase(
+      detect,
+      fs,
+      db,
+      embedder,
+      new SilentLogger(),
+      auditProbe,
+    );
+    const out = await uc.check({ rootPath: ROOT });
+    const entry = out.checks.find((c) => c.id === "encryption.last_export_at");
+    expect(entry?.status).toBe("skipped");
+    expect(entry?.message).toContain("not applicable to mode=private");
+  });
+
+  it("encrypted mode + no probe wired → skipped with explanatory message", async () => {
+    const fs = new FakeFilesystem();
+    const detect = new StubDetect({
+      found: true,
+      workspace: buildWorkspaceWithMode(WorkspaceMode.encryptedMode()),
+      rootPath: ROOT,
+    });
+    const db = new StubDatabaseBootstrap();
+    db.probeResult = { openable: true, schemaVersion: 9 };
+    const embedder = new StubEmbedderProbe();
+    embedder.outcome = { ok: true, dimension: 384, message: "ok" };
+
+    // No 6th arg → probe defaults to null. Backwards-compat path
+    // for callers not yet migrated.
+    const uc = new HealthCheckUseCase(
+      detect,
+      fs,
+      db,
+      embedder,
+      new SilentLogger(),
+    );
+    const out = await uc.check({ rootPath: ROOT });
+    const entry = out.checks.find((c) => c.id === "encryption.last_export_at");
+    expect(entry?.status).toBe("skipped");
+    expect(entry?.message).toContain("probe not wired");
   });
 });


### PR DESCRIPTION
## Summary
Adds an `encryption.last_export_at` entry to the `recall health` / `mem.health` output so the user can detect a `recall export-key` invocation that did NOT originate from them — defense in depth against an unauthorised terminal that ran the command (cf. F-A6-3 threat model in `docs/11 §3` \"Lo que NO protege\" #5).

Closes follow-up tracked **FU-A7-2** (Phase-24 §6.29 A7 security audit / HANDOFF §8).

## Mechanics
- **New shared port** `code/src/shared/application/ports/encryption-audit-probe.port.ts` — `lastExportAt(): Promise<Timestamp | null>`. Lives in `shared/` so workspace's `HealthCheckUseCase` and encryption meet without crossing modularity (ADR-001 / `docs/12 §1.5.1`).
- **New SQLite adapter** `code/src/modules/encryption/infrastructure/persistence/sqlite-encryption-audit-probe.ts` issues `SELECT occurred_at_ms FROM encryption_audit_log WHERE event_type='ExportKeyEmitted' AND outcome='SUCCESS' ORDER BY occurred_at_ms DESC LIMIT 1`. Filtered defensively on outcome=SUCCESS.
- **HealthCheckUseCase** accepts an optional 6th arg `encryptionAuditProbe: EncryptionAuditProbe | null = null`. Semantics:
  - `pass` + ISO 8601 message when probe returns timestamp.
  - `pass` + \"no recall export-key invocation recorded\" when probe returns null (encrypted mode).
  - `skipped` for shared/private modes.
  - `skipped` for back-compat path (probe arg = null).
  - `fail` when probe throws (corrupted audit table surfaces, NOT silently swallowed).
- **Composition root** (`container.ts`) builds `SqliteEncryptionAuditProbe(options.database)` and threads it via new optional `WorkspaceWiringOptions.encryptionAuditProbe`.

## Why no fingerprint exposure
The probe deliberately surfaces ONLY `occurred_at_ms`. `master_key_fp`, `envelope_id`, and `actor_hint` stay contained in the encryption module per the `MasterKeyFingerprint` security invariant + the `EncryptionAuditLogRepository` port contract (write-only at domain boundary).

## Test plan
- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` EXIT=0
- [x] `npm run validate:modules` PASS (no cross-module violations introduced)
- [x] `npx vitest run tests/unit/workspace tests/unit/shared tests/integration/encryption` — 501/501 pass (12 existing health-check + 6 new health-check + 6 new probe integration + the rest unchanged)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)