### PR TITLE
refactor(encryption): FP-A5-5 batch withUnlockedKey invocations

### DIFF
--- a/code/src/modules/encryption/application/use-cases/add-envelope.use-case.ts
+++ b/code/src/modules/encryption/application/use-cases/add-envelope.use-case.ts
@@ -154,40 +154,41 @@ export class AddEnvelopeUseCase implements AddEnvelope {
     }
     const derivedKey = derivation.value;
 
-    // 4. AEAD-wrap the currently-unlocked master key. `withUnlockedKey`
-    //    refuses if the aggregate is locked (already enforced above)
-    //    and exposes the MasterKey VO; we delegate the wrap to the
-    //    cipher port without copying bytes around.
+    // 4 + 5 + 7. Single `withUnlockedKey` callback (FP-A5-5, HANDOFF
+    //             §8): AEAD-wrap, append-to-aggregate, and compute
+    //             fingerprint inside ONE master-key disclosure window.
+    //             The aggregate refuses if locked (already enforced
+    //             above) and exposes the MasterKey VO so the wrap
+    //             delegates to the cipher port without copying bytes.
+    //             Reusing the in-memory master key here (instead of
+    //             re-unwrapping the freshly-wrapped envelope) is
+    //             intentional:
+    //               - The aggregate's `addEnvelope` invariant polices
+    //                 "all envelopes wrap the SAME master key"; the
+    //                 in-memory key trivially satisfies it.
+    //               - Avoids a redundant AEAD operation.
+    //             Batching also reduces the audit surface from three
+    //             withUnlockedKey sites to one, matching the FP-A5-5
+    //             goal of containing master-key access.
     const occurredAt = this.clock.now();
-    const wrappedMasterKey = await config.withUnlockedKey((masterKey) =>
-      this.envelopeCipher.wrap(masterKey, derivedKey),
-    );
-
-    // 5. Build the new envelope VO and append via the aggregate.
-    //    The aggregate emits `KeyEnvelopeAdded` and enforces the
-    //    "all envelopes wrap the SAME master key" invariant via
-    //    `unwrappedMasterKey`. We re-use the in-memory master key
-    //    (NOT re-unwrap from the freshly-wrapped envelope) because:
-    //      - The semantic invariant the aggregate polices is "the
-    //        new envelope wraps the same master key the aggregate
-    //        currently holds". Passing that exact key satisfies the
-    //        invariant trivially.
-    //      - Re-unwrapping would be wasted CPU (two AEAD operations
-    //        when one suffices) and would obscure the intent.
     const newEnvelopeId = KeyId.from(this.idGenerator.generateString());
-    const envelope = KeyEnvelope.create({
-      keyId: newEnvelopeId,
-      encryptedMasterKey: wrappedMasterKey,
-      kdfParams,
-      createdAt: occurredAt,
-      label: input.label,
-    });
-    config.withUnlockedKey((masterKey) => {
+    const fingerprint = await config.withUnlockedKey(async (masterKey) => {
+      const wrapped = await this.envelopeCipher.wrap(masterKey, derivedKey);
+      const envelope = KeyEnvelope.create({
+        keyId: newEnvelopeId,
+        encryptedMasterKey: wrapped,
+        kdfParams,
+        createdAt: occurredAt,
+        label: input.label,
+      });
       config.addEnvelope({
         envelope,
         unwrappedMasterKey: masterKey,
         occurredAt,
       });
+      return masterKey.withBytes((bytes) =>
+        MasterKeyFingerprint.fromMasterKey(bytes),
+      );
     });
 
     // 6. Persist the aggregate (JSON file). If this throws, the
@@ -195,18 +196,6 @@ export class AddEnvelopeUseCase implements AddEnvelope {
     //    visible to disk so the audit trail correctly remains
     //    silent.
     await this.configRepository.save(config);
-
-    // 7. Compute the master-key fingerprint of the currently-unlocked
-    //    key. Stored on BOTH audit rows so a reader can join
-    //    `UnlockSucceeded` with the following `KeyEnvelopeAdded`
-    //    on the fingerprint column. The fingerprint VO never
-    //    surfaces outside the audit adapter (see
-    //    `MasterKeyFingerprint` security invariants).
-    const fingerprint = config.withUnlockedKey((masterKey) =>
-      masterKey.withBytes((bytes) =>
-        MasterKeyFingerprint.fromMasterKey(bytes),
-      ),
-    );
 
     // 8. Append the audit pair atomically.
     const unlockEventId = EventId.from(this.idGenerator.generateString());

--- a/code/src/modules/encryption/application/use-cases/export-master-key.use-case.ts
+++ b/code/src/modules/encryption/application/use-cases/export-master-key.use-case.ts
@@ -5,7 +5,6 @@ import type { Logger } from "../../../../shared/application/ports/logger.port.ts
 import { isErr } from "../../../../shared/domain/types/result.ts";
 import { NonEmptyString } from "../../../../shared/domain/value-objects/non-empty-string.ts";
 import type { Timestamp } from "../../../../shared/domain/value-objects/timestamp.ts";
-import type { EncryptionConfig } from "../../domain/aggregates/encryption-config.ts";
 import { EncryptionLockedError } from "../../domain/errors/encryption-locked-error.ts";
 import { KeyValidationFailedError } from "../../domain/errors/key-validation-failed-error.ts";
 import type { EncryptionAuditLogRepository } from "../../domain/repositories/encryption-audit-log-repository.ts";
@@ -121,16 +120,23 @@ export class ExportMasterKeyUseCase implements ExportMasterKey {
 
     const occurredAt = this.clock.now();
 
-    // 2. Render the master key (read-only over the aggregate). The
-    //    VO defensively copies the bytes; the in-aggregate buffer is
-    //    never aliased outside the closure.
-    const printableMasterKey = this.renderPrintable(config);
-
-    // 3. Compute the master-key fingerprint for the audit row. The
-    //    VO is passed verbatim to the audit port — the SQL adapter
-    //    is the only site allowed to call `.toHex()` (per the VO's
-    //    security invariants).
-    const fingerprint = this.computeFingerprint(config);
+    // 2 + 3. Single `withUnlockedKey` callback that derives BOTH the
+    //         `PrintableMasterKey` and the `MasterKeyFingerprint` from
+    //         the in-aggregate master bytes inside one `withBytes`
+    //         disclosure window. Closes follow-up FP-A5-5 (HANDOFF §8):
+    //         batching the two reads into one callback reduces the
+    //         number of master-key-access sites the audit-reviewer
+    //         has to inspect from 2 to 1, and guarantees both
+    //         derivations observe the SAME byte buffer (defensive
+    //         clone returned by `withBytes`) without round-tripping
+    //         through the aggregate boundary twice.
+    const { printableMasterKey, fingerprint } = config.withUnlockedKey(
+      (masterKey) =>
+        masterKey.withBytes((bytes) => ({
+          printableMasterKey: PrintableMasterKey.fromMasterKey(bytes),
+          fingerprint: MasterKeyFingerprint.fromMasterKey(bytes),
+        })),
+    );
 
     // 4. Emit the single `ExportKeyEmitted` audit row atomically.
     await this.appendAuditRow({ fingerprint, occurredAt });
@@ -144,31 +150,6 @@ export class ExportMasterKeyUseCase implements ExportMasterKey {
   }
 
   // -- private helpers -----------------------------------------------------
-
-  /**
-   * Builds a `PrintableMasterKey` VO from the currently-unlocked
-   * master key. The double `withUnlockedKey` / `withBytes` nesting
-   * keeps the secret bytes inside the audited disclosure surface
-   * (the VO never observes them as an externally-held alias).
-   */
-  private renderPrintable(config: EncryptionConfig): PrintableMasterKey {
-    return config.withUnlockedKey((masterKey) =>
-      masterKey.withBytes((bytes) => PrintableMasterKey.fromMasterKey(bytes)),
-    );
-  }
-
-  /**
-   * Computes the truncated master-key fingerprint of the
-   * currently-unlocked key. Stored on the single audit row so a
-   * forensic reader can correlate `ExportKeyEmitted` with earlier
-   * `UnlockSucceeded` / `KeyEnvelopeAdded` rows on the same key
-   * material.
-   */
-  private computeFingerprint(config: EncryptionConfig): MasterKeyFingerprint {
-    return config.withUnlockedKey((masterKey) =>
-      masterKey.withBytes((bytes) => MasterKeyFingerprint.fromMasterKey(bytes)),
-    );
-  }
 
   /**
    * Appends the single `ExportKeyEmitted` audit row inside one

--- a/code/src/modules/encryption/application/use-cases/rekey-encryption.use-case.ts
+++ b/code/src/modules/encryption/application/use-cases/rekey-encryption.use-case.ts
@@ -247,36 +247,47 @@ export class RekeyEncryptionUseCase implements RekeyEncryption {
     }
     const derivedKey = derivation.value;
 
-    const wrappedMasterKey = await input.config.withUnlockedKey((masterKey) =>
-      this.envelopeCipher.wrap(masterKey, derivedKey),
+    // FP-A5-5 (HANDOFF §8): batch the AEAD wrap + the aggregate
+    // `addEnvelope` invariant check inside ONE `withUnlockedKey`
+    // callback. The smoke-verify (ADR-005 Q2 defence-in-depth) runs
+    // OUTSIDE the master-key window because it operates only on the
+    // already-wrapped ciphertext + `derivedKey`; running it inside
+    // would expand the master-key disclosure surface for zero
+    // security benefit.
+    const newEnvelopeId = KeyId.from(this.idGenerator.generateString());
+    const { envelope, wrappedMasterKey } = await input.config.withUnlockedKey(
+      async (masterKey) => {
+        const wrapped = await this.envelopeCipher.wrap(masterKey, derivedKey);
+        const fresh = KeyEnvelope.create({
+          keyId: newEnvelopeId,
+          encryptedMasterKey: wrapped,
+          kdfParams,
+          createdAt: input.occurredAt,
+          label: input.newPassphraseInput.label,
+        });
+        input.config.addEnvelope({
+          envelope: fresh,
+          unwrappedMasterKey: masterKey,
+          occurredAt: input.occurredAt,
+        });
+        return { envelope: fresh, wrappedMasterKey: wrapped };
+      },
     );
 
-    // Smoke-verify (ADR-005 Q2 defence-in-depth): roundtrip the fresh
-    // envelope by unwrapping it under `derivedKey`. A buggy cipher
-    // (regression, AEAD mismatch, future implementation drift) that
-    // wraps without an immediately-unwrappable result would otherwise
-    // cause the rekey to remove the prior envelopes and leave the
-    // workspace unrecoverable. Failing-fast here keeps the prior
-    // envelopes intact so the user can still unlock with the previous
+    // Smoke-verify: roundtrip the fresh envelope by unwrapping it
+    // under `derivedKey`. A buggy cipher (regression, AEAD mismatch,
+    // future implementation drift) that wraps without an
+    // immediately-unwrappable result would otherwise cause the rekey
+    // to remove the prior envelopes and leave the workspace
+    // unrecoverable. Failing-fast here keeps the prior envelopes
+    // intact so the user can still unlock with the previous
     // passphrase. The unwrap result is discarded — we only assert
-    // success.
+    // success. Note: if this throws, the new envelope WAS already
+    // appended to the in-memory aggregate. The caller's outer
+    // try/catch in `rekey(...)` rolls back the in-memory state by
+    // never calling `repository.save(config)`; the on-disk JSON
+    // therefore stays at the pre-rekey snapshot.
     await this.envelopeCipher.unwrap(wrappedMasterKey, derivedKey);
-
-    const newEnvelopeId = KeyId.from(this.idGenerator.generateString());
-    const envelope = KeyEnvelope.create({
-      keyId: newEnvelopeId,
-      encryptedMasterKey: wrappedMasterKey,
-      kdfParams,
-      createdAt: input.occurredAt,
-      label: input.newPassphraseInput.label,
-    });
-    input.config.withUnlockedKey((masterKey) => {
-      input.config.addEnvelope({
-        envelope,
-        unwrappedMasterKey: masterKey,
-        occurredAt: input.occurredAt,
-      });
-    });
 
     return { envelope, newEnvelopeId };
   }


### PR DESCRIPTION
## Summary
Reduces the number of `withUnlockedKey` call sites across the three multi-key use cases. Each call site is a master-key disclosure window the audit-reviewer has to inspect; batching shrinks that surface.

| Use case | Before | After |
|---|---|---|
| `AddEnvelopeUseCase` | 3 (wrap + addEnvelope + fingerprint) | **1** (single async callback returning fingerprint) |
| `ExportMasterKeyUseCase` | 2 (renderPrintable + computeFingerprint) | **1** (single sync callback yielding both VOs from one `withBytes`) |
| `RekeyEncryptionUseCase` | 3 (wrap + addEnvelope + fingerprint) | **2** (batched wrap+addEnvelope; fingerprint stays separate to preserve `appendRekeyFailed`'s null-safety) |

Closes follow-up tracked **FP-A5-5** (Phase-24 §6.29 A5 security audit / HANDOFF §8).

## Behavior preservation
- All 355 existing tests pass unchanged (18 use-case units + tests/unit/encryption + 3 facade integration suites).
- The `MasterKey.withBytes(...)` defensive-copy discipline is preserved.
- **Rekey smoke-verify**: previously `wrap → smoke-verify → addEnvelope`. Now `wrap+addEnvelope → smoke-verify`. On-disk state is unchanged on failure (no `repository.save` runs); the in-memory aggregate is local to the use-case scope and discarded on throw — no external observer sees the transient state.

## Why Rekey is 3→2 and not 3→1
The smoke-verify operates only on the wrapped ciphertext + `derivedKey`; running it inside `withUnlockedKey` would expand the master-key disclosure surface for zero security benefit. The top-level `computeFingerprint` stays separate because it MUST run before `mintNewEnvelope` so the failure path's `appendRekeyFailed` always has a fingerprint to log.

## Test plan
- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` EXIT=0
- [x] `npx vitest run tests/unit/encryption tests/integration/composition/{add-key,rekey,export-key}-facade.integration.test.ts` — 355/355 pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)