### PR TITLE
docs(jsdoc): O-PR44-3 + O-PR45-1 + O-PR45-2 hardening cycle observations

### DIFF
--- a/code/src/modules/encryption/infrastructure/persistence/json-encryption-config-repository.ts
+++ b/code/src/modules/encryption/infrastructure/persistence/json-encryption-config-repository.ts
@@ -175,6 +175,20 @@ type RawConfig = Record<string, unknown>;
  *   product (single-user CLI / interactive MCP server) does not
  *   exercise the contention vector. Documented as a known
  *   limitation; flock would be a Fase 5 hardening if needed.
+ * - **Lost-update characteristic (O-PR44-3, HANDOFF §8).** Two
+ *   concurrent `save(...)` calls on the same `config.json` will
+ *   race read-merge-rename without any cross-process barrier. The
+ *   second writer reads the file BEFORE the first writer's rename
+ *   commits, merges its slice on top of stale state, and then its
+ *   own rename overwrites the first writer's payload — silently
+ *   dropping the first writer's changes. Same shape as the lost-
+ *   update anomaly in any read-modify-write flow without
+ *   `compare-and-swap`. Mitigations available if the contention
+ *   vector materialises: (a) `flock(2)` on the parent directory
+ *   handle before each read-modify-write, (b) optimistic concurrency
+ *   via a monotonically increasing `revision` field in `config.json`
+ *   that the adapter validates on save. Neither is in scope while
+ *   recall stays single-user-per-workspace.
  *
  * Path safety:
  * - The constructor receives an absolute, canonicalised

--- a/code/src/shared/infrastructure/errors/database-error.ts
+++ b/code/src/shared/infrastructure/errors/database-error.ts
@@ -32,6 +32,17 @@ import { InfrastructureError } from "./infrastructure-error.ts";
  * - Callers that need the path read it from `details.path` /
  *   `details.dir`. Tests that previously asserted on `error.message`
  *   substring should pivot to `error.details.path`.
+ *
+ * **WARNING — wire boundary (O-PR45-2, HANDOFF §8):** `details` MUST
+ * NOT be serialised into the JSON-RPC `data` envelope of an MCP
+ * response. Pino's redact globs (`details.path` / `details.dir`)
+ * fire inside the logger; the wire serialiser is a different code
+ * path. The MCP facade that converts a `DatabaseError` into a
+ * `JsonRpcError` is responsible for picking the wire-safe fields
+ * (e.g. `code`, redacted `message`) and explicitly dropping
+ * `details`. Surfacing `details.path` over the wire would leak the
+ * workspace absolute path to the LLM transcript — the exact threat
+ * §3 of `docs/11-seguridad-modos.md` warns against.
  */
 export type DatabaseErrorCode =
   | "database.open-failed"

--- a/code/src/shared/infrastructure/logger/pino-logger.ts
+++ b/code/src/shared/infrastructure/logger/pino-logger.ts
@@ -62,6 +62,16 @@ export const DEFAULT_REDACT_PATHS: readonly string[] = Object.freeze([
   "*.salt",
   "*.printableMasterKey",
   // Two-level wildcards for request-style envelopes (e.g. headers).
+  //
+  // **Pino glob semantics (O-PR45-1, HANDOFF §8):** the `*` segment
+  // matches EXACTLY ONE intermediate key. So `*.passphrase` redacts
+  // `{req: {passphrase}}` but NOT `{req: {body: {passphrase}}}`.
+  // Two-level paths therefore need an explicit middle segment, as the
+  // `*.headers.authorization` glob shows; pino does not support `**`
+  // recursive matching. If a future caller buries a sensitive value
+  // deeper than two levels, add an explicit glob below or sanitise
+  // the payload at the call site. Today every caller stays within
+  // the two-level shape so no recursion is required.
   "*.headers.authorization",
   "*.headers.cookie",
   // Filesystem paths attached to structured error envelopes


### PR DESCRIPTION
## Summary
Closes 3 of the 11 Phase-17 hardening-cycle observations tracked in HANDOFF §8 as JSDoc-only clarifications. No runtime behavior change.

| Obs | File | Concern |
|---|---|---|
| **O-PR45-2** | `code/src/shared/infrastructure/errors/database-error.ts` | `DatabaseError.details` MUST NOT be serialised into JSON-RPC `data` envelope (LLM-transcript leak). |
| **O-PR45-1** | `code/src/shared/infrastructure/logger/pino-logger.ts` | Pino's `*` glob matches exactly one intermediate key — two-level paths need explicit middle segments; no `**` recursion. |
| **O-PR44-3** | `code/src/modules/encryption/infrastructure/persistence/json-encryption-config-repository.ts` | Concurrent `save(...)` calls race read-merge-rename without a cross-process barrier; lost-update anomaly documented. |

Closes **O-PR44-3**, **O-PR45-1**, **O-PR45-2** (Phase-17 §6.22 / HANDOFF §8). 8 hardening-cycle observations stay OPEN for a future batch (the code-changing ones: TOCTOU chmod, atomic fs.open wx, orphan-temp recovery, fsync durability, env var regex, env var ceiling, late-tick guard).

## Test plan
- [x] `npm run typecheck` EXIT=0
- [x] `npm run lint` EXIT=0
- [x] `npx vitest run tests/unit/shared/infrastructure/errors tests/unit/shared/infrastructure/logger tests/unit/encryption/infrastructure/persistence` — 41/41 pass (no behavior change, tests cover affected files).
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)